### PR TITLE
support getting index from api endpoint name

### DIFF
--- a/app/app.rb
+++ b/app/app.rb
@@ -9,10 +9,12 @@ module OpenDataMaker
         render :home, locals: {'title' => 'Open Data Maker'}
     end
 
-    get '/query' do
+    get '/:endpoint' do
       puts params.inspect
+      index = params['endpoint']
+      params.delete('endpoint')
       query = { query: { match: params }}
-      result = DataMagic.search('cities', query)
+      result = DataMagic.search(query, api:endpoint)
       result.to_json
     end
 

--- a/spec/fixtures/import_all/data.yaml
+++ b/spec/fixtures/import_all/data.yaml
@@ -6,9 +6,10 @@
 # (head -n 1 source.txt && tail -n +2 source.txt | LC_ALL=C sort -k7rn,7 -t$'\t' source.txt) > result.txt
 # head -n 101 results.txt > cities100.txt
 # then convertes to csv and removed " city" from after each city name
-index: cities
+index: city-data
 files:
   cities100.csv:
+    api: cities
     fields:
       USPS: state
       NAME: name

--- a/spec/lib/data_magic_spec.rb
+++ b/spec/lib/data_magic_spec.rb
@@ -77,7 +77,7 @@ eos
 
       it "can find an attribute from an imported file" do
         query = { query: { match: {name: "Paul" }}}
-        result = DataMagic.search('people', query)
+        result = DataMagic.search(query, index: 'people')
         expect(result).to eq([{"name" => "Paul", "address" => "15 Penny Lane"}])
       end
     end
@@ -95,7 +95,7 @@ eos
 
       it "can find an attribute from an imported file" do
         query = { query: { match: {person_name: "Paul" }}}
-        result = DataMagic.search('people', query)
+        result = DataMagic.search(query, index: 'people')
         expect(result).to eq([{"person_name" => "Paul", "street" => "15 Penny Lane"}])
       end
 
@@ -120,14 +120,18 @@ eos
       expect(DataMagic.files.sort).to eq(@csv_files.sort)
     end
 
+    it "can get index name from api endpoint" do
+      expect(DataMagic.find_index_for('cities')).to eq('city-data')
+    end
+
     it "indexes files with yaml mapping" do
       query = { query: { match: {name: "Chicago" }}}
-      result = DataMagic.search('cities', query)
+      result = DataMagic.search(query, api: 'cities')
       expect(result).to eq([{"state"=>"IL", "name"=>"Chicago", "population"=>"2695598", "lattitude"=>"41.837551", "longitude"=>"-87.681844"}])
     end
 
     after(:all) do
-      DataMagic.delete_index('cities')
+      DataMagic.delete_index('city-data')
     end
   end
 end


### PR DESCRIPTION
this makes it so API requests can work without code change, and also I think I've fixed it so default case should work with default index name and csv columns, but test coverage might be weak on that use case