### PR TITLE
cloudfoundry deploy: index when needed, on push

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,8 @@ ruby '2.2.2'
 
 # open-data-maker requirements
 gem 'elasticsearch'
+gem 'cf-app-utils'
+gem 'unicorn'
 
 # Project requirements
 gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
+    cf-app-utils (0.4)
     diff-lcs (1.2.5)
     elasticsearch (1.0.12)
       elasticsearch-api (= 1.0.12)
@@ -23,6 +24,7 @@ GEM
       url_mount (~> 0.2.1)
     i18n (0.7.0)
     json (1.8.3)
+    kgio (2.9.3)
     liquid (3.0.3)
     liquify (0.2.7)
       liquid (>= 2.2.2)
@@ -75,6 +77,7 @@ GEM
       rack
     rack-test (0.6.3)
       rack (>= 1.0)
+    raindrops (0.13.0)
     rake (10.4.2)
     rspec (3.3.0)
       rspec-core (~> 3.3.0)
@@ -102,6 +105,10 @@ GEM
       polyglot (>= 0.3.1)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
+    unicorn (4.9.0)
+      kgio (~> 2.6)
+      rack
+      raindrops (~> 0.7)
     url_mount (0.2.1)
       rack
 
@@ -109,6 +116,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  cf-app-utils
   elasticsearch
   liquid (= 3.0.3)
   liquify
@@ -117,6 +125,7 @@ DEPENDENCIES
   rake
   rspec
   sass
+  unicorn
 
 BUNDLED WITH
    1.10.3

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bundle exec unicorn -p $PORT 

--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,0 +1,3 @@
+worker_processes 2
+timeout 30
+preload_app true

--- a/lib/data_magic.rb
+++ b/lib/data_magic.rb
@@ -8,7 +8,27 @@ class DataMagic
   require 'elasticsearch'
   require 'yaml'
   require 'csv'
-  @@client = Elasticsearch::Client.new #log: true
+
+  puts "--"*40
+  puts "    DataMagic init VCAP_APPLICATION=#{ENV['VCAP_APPLICATION'].inspect}"
+  puts "--"*40
+  if ENV['VCAP_APPLICATION']
+    # Cloud Foundry
+    puts "connect to Cloud Foundry elasticsearch service"
+    require 'cf-app-utils'
+    eservice = CF::App::Credentials.find_by_service_name('eservice')
+    puts "eservice: #{eservice.inspect}"
+    service_uri = eservice['url']
+    puts "service_uri: #{service_uri}"
+    @@client = Elasticsearch::Client.new host: service_uri, log: true
+  else
+    puts "default elasticsearch connection"
+    @@client = Elasticsearch::Client.new #log: true
+  end
+
+  @@files = []
+  @@mapping = {}
+  @@api_endpoints = {}
 
 
   #========================================================================

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,3 @@
+---
+applications:
+-  command: bundle exec rake cf:on_first_instance cf:index && bundle exec unicorn -p $PORT -c ./config/unicorn.rb 

--- a/tasks/cloud_foundry.rake
+++ b/tasks/cloud_foundry.rake
@@ -1,0 +1,46 @@
+require 'data_magic'
+require 'json'
+require 'yaml'
+
+namespace :cf do
+    desc "Only run on the first application instance"
+    task :on_first_instance do
+      puts "--"*40
+      puts "    on_first_instance #{ENV['VCAP_APPLICATION']}"
+      puts "--"*40
+      begin
+       app_data = JSON.parse(ENV['VCAP_APPLICATION'])
+       puts "app_data: #{app_data.inspect}"
+       instance_index = app_data["instance_index"]
+      rescue Exception => e
+       puts "on_first_instance exception: #{e.class} #{e.message}"
+      end
+      puts "instance_index: #{instance_index}"
+      exit(0) unless instance_index == 0
+    end
+
+    desc "Update the Elasticsearch Index if needed"
+    task :index do
+      puts "--"*40
+      puts "     index "
+      puts "--"*40
+      begin
+        data_filepath = File.join(DataMagic.data_path, "data.yaml")
+        config = YAML.load_file(data_filepath)
+        puts "config #{config}"
+        prior_version = ENV['DATA_VERSION']
+        puts "DATA_VERSION: #{ENV['DATA_VERSION'].inspect}"
+        if prior_version != config['version']
+          puts "new data version found, indexing..."
+          DataMagic.delete_all
+          DataMagic.import_all(DataMagic.data_path)
+          ENV['DATA_VERSION'] = config['version']
+          puts "DATA_VERSION:#{ENV['DATA_VERSION'].inspect} config.version:#{config['version']}"
+        end
+      rescue Exception => e
+        puts "index exception: #{e.class} #{e.message}"
+      end
+      puts "======= done ======="
+    end
+
+end


### PR DESCRIPTION
start app with unicorn
using data.yaml version field in the cf:index rake task
probably should be used in index:all, but going to test this with additional data sets before refactoring