### PR TITLE
new data.yaml dictionary format

### DIFF
--- a/lib/data_magic.rb
+++ b/lib/data_magic.rb
@@ -102,14 +102,15 @@ module DataMagic
   end
 
   private
-    def self.create_index(es_index_name)
-      logger.info "create_index #{es_index_name}"
+    def self.create_index(es_index_name, field_types={})
+      field_types = field_types.merge({
+       location: { type: 'geo_point' }
+      })
+      logger.info "create_index #{es_index_name} #{field_types}"
       client.indices.create index: es_index_name, body: {
         mappings: {
           document: {    # for now type 'document' is always used
-            properties: {
-             location: { type: 'geo_point' }
-            }
+            properties: field_types
           }
         }
       }

--- a/lib/data_magic/config.rb
+++ b/lib/data_magic/config.rb
@@ -1,12 +1,12 @@
 module DataMagic
   class Config
-    attr_reader :data_path, :data, :global_mapping, :files, :s3, :api_endpoints
+    attr_reader :data_path, :data, :dictionary, :files, :s3, :api_endpoints
     attr_accessor :page_size
 
     def initialize(options = {})
       @api_endpoints = {}
       @files = []
-      @global_mapping = {}
+      @dictionary = {}
       @page_size = DataMagic::DEFAULT_PAGE_SIZE
       @s3 = options[:s3]
 
@@ -136,7 +136,7 @@ module DataMagic
         logger.debug "config: #{@data.inspect}"
         index = @data['index'] || 'general'
         endpoint = @data['api'] || 'data'
-        @global_mapping = @data['global_mapping'] || {}
+        @dictionary = @data['dictionary'] || {}
         @api_endpoints[endpoint] = {index: index}
 
         file_config = @data['files']

--- a/lib/data_magic/index.rb
+++ b/lib/data_magic/index.rb
@@ -47,7 +47,7 @@ module DataMagic
 
   def self.import_with_dictionary(options = {})
     Config.logger.debug "--- import_with_dictionary --"
-    options[:mapping] = self.config.global_mapping
+    options[:mapping] = self.config.dictionary
     es_index_name = self.config.load_datayaml(options[:data_path])
     logger.info "deleting old index #{es_index_name}"   # TO DO: fix #14
     Stretchy.delete es_index_name

--- a/lib/data_magic/index.rb
+++ b/lib/data_magic/index.rb
@@ -48,9 +48,24 @@ module DataMagic
   def self.import_with_dictionary(options = {})
     Config.logger.debug "--- import_with_dictionary --"
     field_mapping = {}
-    self.config.dictionary.each { |key, value|  field_mapping[value] = key }
+
+    # field_name: name we want as the json key
+    # field_mapping[column_name] = field_name
+    self.config.dictionary.each do |field_name, info|
+      case info
+        when String
+          field_mapping[info] = field_name
+        when Hash
+          column_name = info['source']
+          field_mapping[column_name] = field_name
+        else
+          Config.logger.warn("unexpected dictionary field info " +
+            "for #{field_name}: #{info.inspect} -- expected String or Hash")
+      end
+    end
+    Config.logger.debug("field_mapping: #{field_mapping.inspect}")
     options[:mapping] = field_mapping
-    
+
     es_index_name = self.config.load_datayaml(options[:data_path])
     logger.info "deleting old index #{es_index_name}"   # TO DO: fix #14
     Stretchy.delete es_index_name

--- a/lib/data_magic/index.rb
+++ b/lib/data_magic/index.rb
@@ -47,7 +47,10 @@ module DataMagic
 
   def self.import_with_dictionary(options = {})
     Config.logger.debug "--- import_with_dictionary --"
-    options[:mapping] = self.config.dictionary
+    field_mapping = {}
+    self.config.dictionary.each { |key, value|  field_mapping[value] = key }
+    options[:mapping] = field_mapping
+    
     es_index_name = self.config.load_datayaml(options[:data_path])
     logger.info "deleting old index #{es_index_name}"   # TO DO: fix #14
     Stretchy.delete es_index_name

--- a/sample-data/data.yaml
+++ b/sample-data/data.yaml
@@ -8,11 +8,11 @@ version: cities100-2010
 index: city-data
 api: cities
 dictionary:
-  USPS: state
-  NAME: name
-  POP10: population
-  INTPTLAT: location.lat
-  INTPTLONG: location.lon
+  state: USPS
+  name: NAME
+  population: POP10
+  location.lat: INTPTLAT
+  location.lon: INTPTLONG
 
 files:
   cities100.csv:

--- a/sample-data/data.yaml
+++ b/sample-data/data.yaml
@@ -7,7 +7,7 @@ version: cities100-2010
 # then convertes to csv and removed " city" from after each city name
 index: city-data
 api: cities
-global_mapping:
+dictionary:
   USPS: state
   NAME: name
   POP10: population

--- a/sample-data/data.yaml
+++ b/sample-data/data.yaml
@@ -13,6 +13,9 @@ dictionary:
   population: POP10
   location.lat: INTPTLAT
   location.lon: INTPTLONG
+  land_area:
+    source: ALAND_SQMI
+    type: float
 
 files:
   cities100.csv:

--- a/spec/features/api_spec.rb
+++ b/spec/features/api_spec.rb
@@ -58,13 +58,37 @@ describe 'api' do
 				  "per_page" => DataMagic::DEFAULT_PAGE_SIZE,
 				  "results" => [
 						{"state"=>"IL", "name"=>"Chicago", "population"=>"2695598",
-							"location"=>{"lat"=>41.837551, "lon"=>-87.681844}}						]
+						 "land_area"=>"227.635",   # later we'll make this a float
+						 "location"=>{"lat"=>41.837551, "lon"=>-87.681844}}						]
 				}
 				expect(result).to eq(expected)
 
 			end
 		end
 
+		describe "with float" do
+			before do
+				get '/cities?land_area=302.643'
+			end
+			xit "responds with json" do
+			  expect(last_response).to be_ok
+				expect(last_response.content_type).to eq('application/json')
+
+				result = JSON.parse(last_response.body)
+
+				expected = {
+					"total" => 1,
+				  "page"  => 0,
+				  "per_page" => DataMagic::DEFAULT_PAGE_SIZE,
+				  "results" => [{"state"=>"NY", "name"=>"New York",
+						"population"=>"8175133", "land_area"=>302.643,
+						"location"=>{"lat"=>40.664274, "lon"=>-73.9385}}]
+					}
+				expect(result).to eq(expected)
+
+			end
+
+		end
 		describe "near zipcode" do
 			before do
 				get '/cities?zip=94132&distance=30mi'
@@ -83,8 +107,8 @@ describe 'api' do
 				  "page"  => 0,
 				  "per_page" => DataMagic::DEFAULT_PAGE_SIZE,
 				  "results" => [
-						{"state"=>"CA", "name"=>"Fremont", "population"=>"214089", "location"=>{"lat"=>37.494373, "lon"=>-121.941117}},
-						{"state"=>"CA", "name"=>"Oakland", "population"=>"390724", "location"=>{"lat"=>37.769857, "lon"=>-122.22564}}					]
+						{"state"=>"CA", "name"=>"Fremont", "population"=>"214089", "land_area"=>"77.459", "location"=>{"lat"=>37.494373, "lon"=>-121.941117}},
+						{"state"=>"CA", "name"=>"Oakland", "population"=>"390724", "land_area"=>"55.786", "location"=>{"lat"=>37.769857, "lon"=>-122.22564}}]
 				}
 				expect(result).to eq(expected)
 			end

--- a/spec/fixtures/geo/data.yaml
+++ b/spec/fixtures/geo/data.yaml
@@ -8,8 +8,8 @@
 # then convertes to csv and removed " city" from after each city name
 dictionary:
   city: city
-  lat: location.lat
-  lon: location.lon
+  location.lat: lat
+  location.lon: lon
 
 index: place-data
 api: places

--- a/spec/fixtures/geo/data.yaml
+++ b/spec/fixtures/geo/data.yaml
@@ -6,7 +6,7 @@
 # (head -n 1 source.txt && tail -n +2 source.txt | LC_ALL=C sort -k7rn,7 -t$'\t' source.txt) > result.txt
 # head -n 101 results.txt > cities100.txt
 # then convertes to csv and removed " city" from after each city name
-global_mapping:
+dictionary:
   city: city
   lat: location.lat
   lon: location.lon

--- a/spec/fixtures/import_with_dictionary/data.yaml
+++ b/spec/fixtures/import_with_dictionary/data.yaml
@@ -7,7 +7,7 @@
 version: fixture-import-all
 index: city-data
 api: cities
-global_mapping:
+dictionary:
   USPS: state
   NAME: name
   POP10: population

--- a/spec/fixtures/import_with_dictionary/data.yaml
+++ b/spec/fixtures/import_with_dictionary/data.yaml
@@ -8,11 +8,11 @@ version: fixture-import-all
 index: city-data
 api: cities
 dictionary:
-  USPS: state
-  NAME: name
-  POP10: population
-  INTPTLAT: latitude
-  INTPTLONG: longitude
+  state: USPS
+  name: NAME
+  population: POP10
+  latitude: INTPTLAT
+  longitude: INTPTLONG
 
 files:
   cities50.csv:

--- a/spec/lib/data_magic/config_spec.rb
+++ b/spec/lib/data_magic/config_spec.rb
@@ -28,11 +28,10 @@ describe DataMagic::Config do
       end
     end
     it "has config data" do
-      default_config = {"version"=>"cities100-2010", "index"=>"city-data", "api"=>"cities",
-        "dictionary"=>{"USPS"=>"state", "NAME"=>"name", "POP10"=>"population",
-                           "INTPTLAT"=>"location.lat", "INTPTLONG"=>"location.lon"},
-        "files"=>{"cities100.csv"=>{}},
-        "data_path"=>"./sample-data"}
+      default_config = {"version"=>"cities100-2010",
+        "index"=>"city-data", "api"=>"cities",
+        "dictionary"=>{"state"=>"USPS", "name"=>"NAME", "population"=>"POP10", "location.lat"=>"INTPTLAT", "location.lon"=>"INTPTLONG"},
+        "files"=>{"cities100.csv"=>{}}, "data_path"=>"./sample-data"}
       expect(config.data).to eq(default_config)
     end
 

--- a/spec/lib/data_magic/config_spec.rb
+++ b/spec/lib/data_magic/config_spec.rb
@@ -29,7 +29,7 @@ describe DataMagic::Config do
     end
     it "has config data" do
       default_config = {"version"=>"cities100-2010", "index"=>"city-data", "api"=>"cities",
-        "global_mapping"=>{"USPS"=>"state", "NAME"=>"name", "POP10"=>"population",
+        "dictionary"=>{"USPS"=>"state", "NAME"=>"name", "POP10"=>"population",
                            "INTPTLAT"=>"location.lat", "INTPTLONG"=>"location.lon"},
         "files"=>{"cities100.csv"=>{}},
         "data_path"=>"./sample-data"}

--- a/spec/lib/data_magic/config_spec.rb
+++ b/spec/lib/data_magic/config_spec.rb
@@ -30,7 +30,9 @@ describe DataMagic::Config do
     it "has config data" do
       default_config = {"version"=>"cities100-2010",
         "index"=>"city-data", "api"=>"cities",
-        "dictionary"=>{"state"=>"USPS", "name"=>"NAME", "population"=>"POP10", "location.lat"=>"INTPTLAT", "location.lon"=>"INTPTLONG"},
+        "dictionary"=>{"state"=>"USPS", "name"=>"NAME", "population"=>"POP10",
+                       "location.lat"=>"INTPTLAT", "location.lon"=>"INTPTLONG",
+                       "land_area"=>{"source"=>"ALAND_SQMI", "type"=>"float"}},
         "files"=>{"cities100.csv"=>{}}, "data_path"=>"./sample-data"}
       expect(config.data).to eq(default_config)
     end

--- a/spec/lib/data_magic/search_spec.rb
+++ b/spec/lib/data_magic/search_spec.rb
@@ -52,7 +52,7 @@ describe "DataMagic #search" do
         DataMagic.init(load_now: false)
         options = {}
         options[:fields] = {name: 'person_name', address: 'street'}
-        options[:override_global_mapping] = {}
+        options[:override_dictionary] = {}
         num_rows, fields = DataMagic.import_csv(address_data, options)
         expect(fields.sort).to eq(options[:fields].values.sort)
       end


### PR DESCRIPTION
partial implementation of issue #8
global_mapping renamed to dictionary
field name is now the key 
source: specifies the column name
types can be specified, but aren't hooked up

