### PR TITLE
List endpoints

### DIFF
--- a/app/app.rb
+++ b/app/app.rb
@@ -22,6 +22,10 @@ module OpenDataMaker
     end
 
     get :index do
+      render :home, locals: {'title' => 'Open Data Maker'}
+    end
+
+    get :endpoints do
       content_type :json
       endpoints = DataMagic.config.api_endpoints.keys.map { |key|
         {

--- a/spec/features/api_spec.rb
+++ b/spec/features/api_spec.rb
@@ -26,6 +26,35 @@ describe 'api' do
 		#expect(DataMagic.client.indices.get(index: '_all')).to be_empty
 	end
 
+  it "loads the endpoint list" do
+    get "/endpoints"
+
+    expect(last_response).to be_ok
+    expect(last_response.content_type).to eq('application/json')
+
+    result = JSON.parse(last_response.body)
+    expected = {
+      'endpoints'=>[
+        'name'=>'cities',
+        'url'=>'/cities',
+      ]
+    }
+    expect(result).to eq expected
+  end
+
+  it "raises a 404 on missing endpoints" do
+    get "/missing"
+    expect(last_response.status).to eq(404)
+    expect(last_response.content_type).to eq('application/json')
+
+    result = JSON.parse(last_response.body)
+    expected = {
+      "error"=>404,
+      "message"=>"missing not found. Available endpoints: cities",
+    }
+    expect(result).to eq(expected)
+  end
+
 	describe "query" do
 		describe "with terms" do
 			before do


### PR DESCRIPTION
Motivation: IMO, APIs should be self-documenting where possible, and users shouldn't have to hit a 404 to find a list of valid endpoints.

* Add an endpoint that lists available data endpoints with URLs:
```
{
  "endpoints": [
    "name": "cities",
    "url": "/cities"
  ],
  ...
}
```
* Throw a real 404 on missing pages (previously, we were returning a 200 status code with a 404 error message
* Update tests

I don't know which other routes you all were thinking of adding going forward, so if the proposed `/endpoints` route conflicts with anything, I'm happy to revise. I was thinking of having `/` return a list of endpoints instead of HTML, but figured you might have plans for that route.