### PR TITLE
Idempotent index

### DIFF
--- a/lib/data_magic.rb
+++ b/lib/data_magic.rb
@@ -78,7 +78,10 @@ module DataMagic
     # binding.pry
     squery = squery.where(terms) unless terms.empty?
 
-    full_query = {index: index_name, body: {
+    full_query = {
+      index: index_name,
+      type: 'document',
+      body: {
         from: page,
         size: per_page,
         query: squery.to_search

--- a/lib/data_magic.rb
+++ b/lib/data_magic.rb
@@ -75,7 +75,6 @@ module DataMagic
     terms.delete(:per_page)
 
     # logger.info "--> terms: #{terms.inspect}"
-    # binding.pry
     squery = squery.where(terms) unless terms.empty?
 
     full_query = {
@@ -107,8 +106,14 @@ module DataMagic
   private
     def self.create_index(es_index_name, field_types={})
       field_types = field_types.merge({
-       location: { type: 'geo_point' }
+        location: {type: 'geo_point'}
       })
+      if not config.nil?
+        props = config.data['unique'].map { |unique|
+          [unique, {type: 'string', index: 'not_analyzed'}]
+        }
+        field_types = field_types.merge(Hash[props])
+      end
       logger.info "create_index #{es_index_name} #{field_types}"
       client.indices.create index: es_index_name, body: {
         mappings: {

--- a/lib/data_magic/config.rb
+++ b/lib/data_magic/config.rb
@@ -133,6 +133,7 @@ module DataMagic
         @files = []
         config_text = read_path("#{directory_path}/data.yaml")
         @data = YAML.load(config_text)
+        @data['unique'] ||= []
         logger.debug "config: #{@data.inspect}"
         index = @data['index'] || 'general'
         endpoint = @data['api'] || 'data'

--- a/spec/lib/data_magic/config_spec.rb
+++ b/spec/lib/data_magic/config_spec.rb
@@ -33,7 +33,8 @@ describe DataMagic::Config do
         "dictionary"=>{"state"=>"USPS", "name"=>"NAME", "population"=>"POP10",
                        "location.lat"=>"INTPTLAT", "location.lon"=>"INTPTLONG",
                        "land_area"=>{"source"=>"ALAND_SQMI", "type"=>"float"}},
-        "files"=>{"cities100.csv"=>{}}, "data_path"=>"./sample-data"}
+        "files"=>{"cities100.csv"=>{}}, "data_path"=>"./sample-data",
+        "unique"=>[]}
       expect(config.data).to eq(default_config)
     end
 

--- a/spec/lib/data_magic/import_csv_spec.rb
+++ b/spec/lib/data_magic/import_csv_spec.rb
@@ -46,7 +46,7 @@ eos
     data = StringIO.new(data_str)
     num_rows, fields = DataMagic.import_csv(data)
     expect(num_rows).to be(2)
-    expect(fields).to eq( [:a,:b] )
+    expect(fields).to eq(['a', 'b'])
   end
 
 end

--- a/spec/lib/data_magic/import_with_dictionary_spec.rb
+++ b/spec/lib/data_magic/import_with_dictionary_spec.rb
@@ -1,6 +1,41 @@
 require 'spec_helper'
 require 'data_magic'
 
+describe "unique key(s)" do
+
+  before :example do
+    DataMagic.destroy
+    ENV['DATA_PATH'] = './spec/fixtures/import_with_dictionary'
+  end
+  after :example do
+    DataMagic.destroy
+  end
+
+  it "loads records once by state" do
+    DataMagic.config = DataMagic::Config.new
+    DataMagic.config.data['unique'] = ['state']
+    2.times { DataMagic.import_with_dictionary }
+    result = DataMagic.search({})
+    expect(result['total']).to eq(35)
+  end
+
+  it "loads records once by city" do
+    DataMagic.config = DataMagic::Config.new
+    DataMagic.config.data['unique'] = ['name']
+    2.times { DataMagic.import_with_dictionary }
+    result = DataMagic.search({})
+    expect(result['total']).to eq(100)
+  end
+
+  it "duplicates records with no unique keys" do
+    DataMagic.config = DataMagic::Config.new
+    2.times { DataMagic.import_with_dictionary }
+    result = DataMagic.search({})
+    expect(result['total']).to eq(200)
+  end
+
+end
+
 describe "DataMagic #import_with_dictionary" do
   let (:expected) { {
             "total" => 1,

--- a/spec/lib/data_magic/import_with_dictionary_spec.rb
+++ b/spec/lib/data_magic/import_with_dictionary_spec.rb
@@ -11,6 +11,13 @@ describe "unique key(s)" do
     DataMagic.destroy
   end
 
+  it "duplicates records with no unique keys" do
+    DataMagic.config = DataMagic::Config.new
+    2.times { DataMagic.import_with_dictionary }
+    result = DataMagic.search({})
+    expect(result['total']).to eq(200)
+  end
+
   it "loads records once by state" do
     DataMagic.config = DataMagic::Config.new
     DataMagic.config.data['unique'] = ['state']
@@ -25,13 +32,6 @@ describe "unique key(s)" do
     2.times { DataMagic.import_with_dictionary }
     result = DataMagic.search({})
     expect(result['total']).to eq(100)
-  end
-
-  it "duplicates records with no unique keys" do
-    DataMagic.config = DataMagic::Config.new
-    2.times { DataMagic.import_with_dictionary }
-    result = DataMagic.search({})
-    expect(result['total']).to eq(200)
   end
 
 end

--- a/spec/lib/data_magic/import_with_dictionary_spec.rb
+++ b/spec/lib/data_magic/import_with_dictionary_spec.rb
@@ -42,8 +42,6 @@ describe "DataMagic #import_with_dictionary" do
   end
 
   it "indexes rows from all the files" do
-    # currently fails with 101 rows, one has blank name
-    # perhaps it is reading a blank line at the end of one of the files?
     result = DataMagic.search({}, api: 'cities')
     expect(result["total"]).to eq(100)
   end


### PR DESCRIPTION
Add the option for idempotent imports if the `unique` field is specified in `data.yaml`. As implemented, `unique` is a list of fields on which imported documents must be, well, unique.

One wrinkle: for this patch to work, we have to tell Elastic not to analyze unique fields, else we can't check for exact matches against them--which we have to do to determine if those fields already exist in the index. This is kind of a hack--a better solution might be to create a hidden field that isn't analyzed so that specifying fields as unique doesn't change their search properties. I'll think about this and see if I can write something more robust. In the meantime, feedback welcome!