### PR TITLE
Allow result to contain only specific fields (not the whole document)

### DIFF
--- a/app/app.rb
+++ b/app/app.rb
@@ -58,7 +58,9 @@ module OpenDataMaker
           message: "#{endpoint} not found. Available endpoints: #{DataMagic.config.api_endpoints.keys.join(',')}"
         }.to_json
       end
-      DataMagic.search(params, api:endpoint).to_json
+      fields = params.delete('fields') || ""
+      fields = fields.split(',')
+      DataMagic.search(params, api:endpoint, fields:fields).to_json
     end
 
     ##

--- a/lib/data_magic.rb
+++ b/lib/data_magic.rb
@@ -58,9 +58,11 @@ module DataMagic
   # thin layer on elasticsearch query
   def self.search(terms, options = {})
     terms = IndifferentHash.new(terms)
+    options[:fields] ||= []
+    fields = options[:fields].map { |field| field.to_s }
     index_name = index_name_from_options(options)
     logger.info "search terms:#{terms.inspect}"
-    squery = Stretchy.query(type: 'document')
+    squery = Stretchy.query
 
     distance = terms[:distance]
     if distance && !distance.empty?
@@ -89,6 +91,9 @@ module DataMagic
         query: squery.to_search
       }
     }
+    if not fields.empty?
+      full_query[:body][:fields] = fields
+    end
 
     logger.info "===========> full_query:#{full_query.inspect}"
 
@@ -96,8 +101,25 @@ module DataMagic
     logger.info "result: #{result.inspect}"
     hits = result["hits"]
     total = hits["total"]
-    hits["hits"].map {|hit| hit["_source"]}
-    results = hits["hits"].map {|hit| hit["_source"]}
+    results = []
+    if fields.empty?
+      # we're getting the whole document and we can find in _source
+      results = hits["hits"].map {|hit| hit["_source"]}
+    else
+      # we're getting a subset of fields...
+      results = hits["hits"].map do |hit|
+        found = hit["fields"]
+        # each result looks like this:
+        # {"city"=>["Springfield"], "address"=>["742 Evergreen Terrace"]}
+
+        found.keys.each { |key| found[key] = found[key][0] }
+        # now it should look like this:
+        # {"city"=>"Springfield", "address"=>"742 Evergreen Terrace
+        found
+      end
+    end
+
+    # assemble a simpler json document to return
     {
       "total" => total,
       "page" => page,

--- a/spec/features/api_spec.rb
+++ b/spec/features/api_spec.rb
@@ -69,7 +69,7 @@ describe 'api', type: 'feature' do
 	end
 
 	describe "query" do
-		describe "with terms" do
+		describe "with one term" do
 			before do
 				get '/cities?name=Chicago'
 			end
@@ -94,6 +94,24 @@ describe 'api', type: 'feature' do
 				expect(result).to eq(expected)
 
 			end
+		end
+		describe "with options" do
+			it "can return a subset of fields" do
+				get '/cities?state=MA&fields=name,population'
+
+				expect(last_response).to be_ok
+				result = JSON.parse(last_response.body)
+
+				expected = {
+					"total" => 1,
+					"page"  => 0,
+					"per_page" => DataMagic::DEFAULT_PAGE_SIZE,
+					"results" => [{"name"=>"Boston", "population"=>"617594"}]
+				}
+				expect(result).to eq(expected)
+
+			end
+
 		end
 
 		describe "with float" do

--- a/spec/fixtures/data.rb
+++ b/spec/fixtures/data.rb
@@ -5,7 +5,7 @@ def address_data
 name,address,city
 Paul,15 Penny Lane,Liverpool
 Michelle,600 Pennsylvania Avenue,Washington
-Marilyn,1313 Mockingbird Lane,Burbank
+Marilyn,1313 Mockingbird Lane,Springfield
 Sherlock,221B Baker Street,London
 Clark,66 Lois Lane,Smallville
 Bart,742 Evergreen Terrace,Springfield

--- a/spec/lib/data_magic/search_spec.rb
+++ b/spec/lib/data_magic/search_spec.rb
@@ -11,7 +11,7 @@ describe "DataMagic #search" do
           } }
 
   describe "with terms" do
-    describe "default" do
+    describe "as strings" do
       before (:all) do
         DataMagic.init(load_now: false)
         num_rows, fields = DataMagic.import_csv(address_data)
@@ -20,23 +20,47 @@ describe "DataMagic #search" do
         DataMagic.destroy
       end
 
-      it "can find an attribute from an imported file" do
+      it "can find document with one attribute" do
         result = DataMagic.search({name: "Marilyn"})
-        expected["results"] = [{"name" => "Marilyn", "address" => "1313 Mockingbird Lane", "city" => "Burbank"}]
+        expected["results"] = [{"name" => "Marilyn", "address" => "1313 Mockingbird Lane", "city" => "Springfield"}]
         expect(result).to eq(expected)
       end
 
-      it "can find based on multiple attributes from an imported file" do
+      it "can find document with multiple search terms" do
         result = DataMagic.search({name: "Paul", city:"Liverpool"})
         expected["results"] = [{"name" => "Paul", "address" => "15 Penny Lane", "city" => "Liverpool"}]
         expect(result).to eq(expected)
       end
 
+      it "can return a single attribute" do
+        result = DataMagic.search({city: "Springfield"}, fields:[:address])
+        expected["results"] = [
+          {"address" => "1313 Mockingbird Lane"},
+          {"address"=>"742 Evergreen Terrace"},
+        ]
+        expected["total"] = 2
+        DataMagic.logger.info "======= EXPECTED: #{expected.inspect}"
+        result["results"] = result["results"].sort_by { |k| k["address"] }
+        expect(result).to eq(expected)
+      end
+
+      it "can return a subset of attributes" do
+        result = DataMagic.search({city: "Springfield"}, fields:[:address, :city])
+        expected["results"] = [
+          {"city"=>"Springfield", "address"=>"1313 Mockingbird Lane"},
+          {"city"=>"Springfield", "address"=>"742 Evergreen Terrace"},
+        ]
+        result["results"] = result["results"].sort_by { |k| k["address"] }
+        expected["total"] = 2
+        expect(result).to eq(expected)
+      end
+
+
       it "supports pagination" do
         result = DataMagic.search({address: "Lane", page:1, per_page: 3})
         expected["results"] = [{"name" => "Paul", "address" => "15 Penny Lane", "city" => "Liverpool"}]
         expected = {"total"=>4, "page"=>1, "per_page"=>3,
-            "results"=>[{"name"=>"Marilyn", "address"=>"1313 Mockingbird Lane", "city"=>"Burbank"},
+            "results"=>[{"name"=>"Marilyn", "address"=>"1313 Mockingbird Lane", "city"=>"Springfield"},
                         {"name"=>"Peter", "address"=>"66 Parker Lane", "city"=>"New York"},
                         {"name"=>"Paul", "address"=>"15 Penny Lane", "city"=>"Liverpool"}]}
 


### PR DESCRIPTION
library #search now supports 'fields' option
application API expects comma-separated list, like: fields=name,another
fixes: https://github.com/18F/open-data-maker/issues/76