### PR TITLE
update NOTES to match current state of the code

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -1,7 +1,13 @@
 
 
-the config (specified by DATA_PATH/data.yaml) is loaded the first time it is needed and then stored in memory
+Details about the data are specified by DATA_PATH/data.yaml.  
+Where DATA_PATH is an environment variable, which may be:
+    s3://username:password@bucket_name/path
+    s3://bucket_name/path
+    s3://bucket_name
+    a local path like: './data'
 
-(A) CloudFoundry: configuration is stored in Elastic Search in a single document of type 'config' with id 1  (this document is checked at startup to check the version field, if the new config has a new version, then we delete and re-index) 
 
-(B) Locally or elsewhere: rake import_with_dictionary checks DATA_VERSION env variable. If new config has a different version, then we index.  Issue [#50](https://github.com/18F/open-data-maker/issues/50) open to move these to the approach we're using in (A)
+This file is loaded the first time it is needed and then stored in memory.  The contents of data.yaml are stored as JSON in Elastic Search in a single document of type 'config' with id 1.  
+
+The version field of this document is checked at startup. If the new config has a new version, then we delete the whole index and re-index all of the files referred to in the data.yaml files section.


### PR DESCRIPTION
we no longer use DATA_VERSION
also, added details about how to specify S3 in DATA_PATH
fixes: https://github.com/18F/open-data-maker/issues/50