### PR TITLE
[WIP] Bulk insert

### DIFF
--- a/lib/data_magic/config.rb
+++ b/lib/data_magic/config.rb
@@ -179,6 +179,7 @@ module DataMagic
       else
         logger.debug "load config #{directory_path.inspect}"
         @data = load_yaml(directory_path)
+        @data['unique'] ||= []
         logger.debug "config: #{@data.inspect}"
         @data['index'] ||= clean_index(@data_path)
         endpoint = @data['api'] || clean_index(@data_path)

--- a/lib/data_magic/index.rb
+++ b/lib/data_magic/index.rb
@@ -4,6 +4,29 @@ include ActionView::Helpers::DateHelper  # for distance_of_time_in_words (loggin
 
 module DataMagic
 
+  def self.parse_rows(data, fields, options, additional)
+    parsed = CSV.parse(
+      data,
+      headers: true,
+      header_converters: lambda { |str| str.strip.to_sym }
+    )
+    parsed.map { |row| parse_row(row, fields, options, additional) }
+  end
+
+  def self.parse_row(row, fields, options, additional)
+    row = row.to_hash
+    row = map_field_names(row, fields, options) unless fields.empty?
+    row = row.merge(additional) if additional
+    row = NestedHash.new.add(row)
+    row
+  end
+
+  def self.get_id(row)
+    config.data['unique'].length > 0 ?
+      config.data['unique'].map { |field| row[field] }.join(':') :
+      nil
+  end
+
   # data could be a String or an io stream
   def self.import_csv(data, options={})
     es_index_name = self.create_index
@@ -18,34 +41,28 @@ module DataMagic
       data = data.encode('UTF-8', invalid: :replace, replace: '')
     end
 
-    fields = nil
     new_field_names = options[:fields] || {}
     new_field_names = new_field_names.merge(additional_fields)
-    num_rows = 0
     begin
-      CSV.parse(data, headers:true, :header_converters=> lambda {|f| f.strip.to_sym }) do |row|
-        fields ||= row.headers
-        row = row.to_hash
-        row = map_field_names(row, new_field_names, options) unless new_field_names.empty?
-        row = row.merge(additional_data) if additional_data
-        row = NestedHash.new.add(row)
-        #logger.debug "indexing: #{row.inspect}"
-        client.index index: es_index_name, type:'document', body: row
-        num_rows += 1
-        if num_rows % 500 == 0
-          print "#{num_rows}..."; $stdout.flush
-        end
-      end
+      rows = parse_rows(data, new_field_names, options, additional_data)
     rescue Exception => e
-      Config.logger.error "row #{num_rows}: #{e.message}"
+      Config.logger.error e.message
+      rows = []
     end
+    rows.each { |row|
+      client.index({
+        index: es_index_name,
+        id: get_id(row),
+        type: 'document',
+        body: row,
+      })
+    }
 
-    raise InvalidData, "invalid file format or zero rows" if num_rows == 0
+    raise InvalidData, "invalid file format or zero rows" if rows.length == 0
+    client.indices.refresh index: es_index_name
 
-    fields = new_field_names.values unless new_field_names.empty?
-    client.indices.refresh index: es_index_name if num_rows > 0
-
-    return [num_rows, fields ]
+    fields = rows.map(&:keys).flatten.uniq
+    return [rows.length, fields]
   end
 
   def self.import_with_dictionary(options = {})
@@ -72,10 +89,8 @@ module DataMagic
     options = options.merge(config.data['options'])
 
     es_index_name = self.config.load_datayaml(options[:data_path])
-    logger.info "deleting old index #{es_index_name}"   # TO DO: fix #14
-    Stretchy.delete es_index_name
     logger.info "creating #{es_index_name}"   # TO DO: fix #14
-    self.create_index es_index_name
+    self.create_index_if_needed es_index_name
     logger.info "files: #{self.config.files}"
     self.config.files.each do |filepath|
       fname = filepath.split('/').last
@@ -84,7 +99,7 @@ module DataMagic
       #begin
         logger.debug "reading #{filepath}"
         data = config.read_path(filepath)
-        rows, fields = DataMagic.import_csv(data, options)
+        rows, _ = DataMagic.import_csv(data, options)
         logger.debug "imported #{rows} rows"
       #rescue Exception => e
       #  Config.logger.debug "Error: skipping #{filepath}, #{e.message}"

--- a/spec/lib/data_magic/config_spec.rb
+++ b/spec/lib/data_magic/config_spec.rb
@@ -84,7 +84,8 @@ describe DataMagic::Config do
                        "location.lat"=>"INTPTLAT", "location.lon"=>"INTPTLONG",
                        "land_area"=>{"source"=>"ALAND_SQMI", "type"=>"float"}},
         "files"=>{"cities100.csv"=>{}}, "data_path"=>"./sample-data",
-        "options"=>{}
+        "options"=>{},
+        "unique"=>[],
     }
       expect(config.data).to eq(default_config)
     end

--- a/spec/lib/data_magic/import_csv_spec.rb
+++ b/spec/lib/data_magic/import_csv_spec.rb
@@ -46,7 +46,7 @@ eos
     data = StringIO.new(data_str)
     num_rows, fields = DataMagic.import_csv(data)
     expect(num_rows).to be(2)
-    expect(fields).to eq( [:a,:b] )
+    expect(fields).to eq(['a', 'b'])
   end
 
 end

--- a/spec/lib/data_magic/import_with_dictionary_spec.rb
+++ b/spec/lib/data_magic/import_with_dictionary_spec.rb
@@ -1,6 +1,41 @@
 require 'spec_helper'
 require 'data_magic'
 
+describe "unique key(s)" do
+
+  before :example do
+    DataMagic.destroy
+    ENV['DATA_PATH'] = './spec/fixtures/import_with_dictionary'
+  end
+  after :example do
+    DataMagic.destroy
+  end
+
+  it "duplicates records with no unique keys" do
+    DataMagic.config = DataMagic::Config.new
+    2.times { DataMagic.import_with_dictionary }
+    result = DataMagic.search({})
+    expect(result['total']).to eq(200)
+  end
+
+  it "loads records once by state" do
+    DataMagic.config = DataMagic::Config.new
+    DataMagic.config.data['unique'] = ['state']
+    2.times { DataMagic.import_with_dictionary }
+    result = DataMagic.search({})
+    expect(result['total']).to eq(35)
+  end
+
+  it "loads records once by city" do
+    DataMagic.config = DataMagic::Config.new
+    DataMagic.config.data['unique'] = ['name']
+    2.times { DataMagic.import_with_dictionary }
+    result = DataMagic.search({})
+    expect(result['total']).to eq(100)
+  end
+
+end
+
 describe "DataMagic #import_with_dictionary" do
   let (:expected) { {
             "total" => 1,


### PR DESCRIPTION
Bulk-insert records for faster indexing. Branched from #84, since this requires factoring document parsing and insertion into separate methods. As an informal comparison, I ran the test suite with and without this change, and the tests run about 50% faster with bulk inserts--should be useful for larger data sets.