### PR TITLE
new mapping requires new index

### DIFF
--- a/lib/data_magic.rb
+++ b/lib/data_magic.rb
@@ -131,16 +131,13 @@ module DataMagic
   private
     def self.create_index(es_index_name = nil, field_types={})
       es_index_name ||= self.config.scoped_index_name
-      logger.debug "======== create_index #{es_index_name} ======="
+      logger.debug "====> create_index #{es_index_name}"
       field_types['location'] = 'geo_point'
       es_types = {}
       field_types.each do |key, type|
         es_types[key] = { type: type }
       end
-      # field_types = field_types.merge({
-      #  location: { type: 'geo_point' }
-      # })
-      logger.info "es type mapping #{es_types.inspect}"
+      # logger.info "es type mapping #{es_types.inspect}"
       begin
         client.indices.create index: es_index_name, body: {
           mappings: {

--- a/lib/data_magic/index.rb
+++ b/lib/data_magic/index.rb
@@ -22,7 +22,7 @@ module DataMagic
   # data could be a String or an io stream
   def self.import_csv(data, options={})
     es_index_name = self.create_index
-    Config.logger.debug "Indexing data -- index_name: #{es_index_name}, options: #{options}"
+    Config.logger.debug "Indexing data -- index_name: #{es_index_name}" #options: #{options}"
     additional_fields = options[:mapping] || {}
     additional_data = options[:add_data]
     Config.logger.debug "additional_data: #{additional_data.inspect}"
@@ -51,6 +51,9 @@ module DataMagic
           type: 'document',
           body: row,
         })
+        if num_rows % 500 == 0
+          logger.info "indexing rows: #{num_rows}..."
+        end
         num_rows += 1
       end
 
@@ -84,7 +87,7 @@ module DataMagic
             "for #{field_name}: #{info.inspect} -- expected String or Hash")
       end
     end
-    logger.debug("field_mapping: #{field_mapping.inspect}")
+    #logger.debug("field_mapping: #{field_mapping.inspect}")
     options[:mapping] = field_mapping
     options = options.merge(config.data['options'])
 
@@ -133,6 +136,7 @@ private
   def self.map_field_types(row, field_types = {})
     row.each do |key, value|
       type = field_types[key.to_sym] || field_types[key.to_s]
+      #logger.info "key: #{key} type: #{type}"
       case type
         when "float"
           row[key] = value.to_f

--- a/spec/lib/nested_hash_spec.rb
+++ b/spec/lib/nested_hash_spec.rb
@@ -17,5 +17,15 @@ describe NestedHash do
     expect(result).to eq(symbol_keys_result)
   end
 
+  context "deeply nested" do
+    let(:input) { {"info.loc.x" => 0.11, "info.loc.y" => 0.222, "foo.a" => 10, "foo.b" => 20}}
+    let(:expected) { {"info" => {"loc" => {"x" => 0.11, "y" => 0.222}}, "foo" => {"a" => 10, "b" => 20}}}
+
+    it "creates nested hash elements for string keys with '.'" do
+      result = NestedHash.new.add(input)
+      expect(result).to eq(expected)
+    end
+
+  end
 
 end


### PR DESCRIPTION
after testing with more types, and with more nested fields, I realized that whenver there is a new mapping, we need to delete the index and re-index all the data.  Technically we could add a column without re-indexing, but this will work for starters.
Also made logging less verbose, truncating so lines for really big data.yaml