### PR TITLE
[WIP] Read CSVs in chunks using smarter_csv.

### DIFF
--- a/lib/data_magic.rb
+++ b/lib/data_magic.rb
@@ -29,6 +29,7 @@ module DataMagic
   end
 
   DEFAULT_PAGE_SIZE = 20
+  DEFAULT_CHUNK_SIZE = 500
   DEFAULT_EXTENSIONS = ['.csv']
   DEFAULT_PATH = './sample-data'
   class InvalidData < StandardError

--- a/lib/data_magic/config.rb
+++ b/lib/data_magic/config.rb
@@ -131,12 +131,12 @@ module DataMagic
       scheme = uri.scheme
       case scheme
         when nil
-          File.read(uri.path)
+          File.open(uri.path)
         when "s3"
           key = uri.path
           key[0] = ''  # remove initial /
-          response = @s3.get_object(bucket: uri.hostname, key: key)
-          response.body.read
+          file = Tempfile.new(uri.path)
+          @s3.get_object(bucket: uri.hostname, key: key, response_target: file).body
         else
           raise ArgumentError, "unexpected scheme: #{scheme}"
       end

--- a/lib/data_magic/index.rb
+++ b/lib/data_magic/index.rb
@@ -27,51 +27,46 @@ module DataMagic
     result
   end
 
-  # data could be a String or an io stream
-  def self.import_csv(data, options={})
+  def self.import_csv(data, options = {})
     es_index_name = self.create_index
     Config.logger.debug "Indexing data -- index_name: #{es_index_name}" #options: #{options}"
     additional_fields = options[:mapping] || {}
     additional_data = options[:add_data]
     Config.logger.debug "additional_data: #{additional_data.inspect}"
 
-    data = data.read if data.respond_to?(:read)
-
-    if options[:force_utf8]
-      data = data.encode('UTF-8', invalid: :replace, replace: '')
-    end
+    data = File.open(data) if !data.respond_to?(:read)
 
     new_field_names = options[:fields] || {}
     new_field_names = new_field_names.merge(additional_fields)
     num_rows = 0
     headers = nil
     begin
-      CSV.parse(
+      CSV.new(
         data,
         headers: true,
         header_converters: lambda { |str| str.strip.to_sym }
-      ) do |row|
-        row = parse_row(row, new_field_names, options, additional_data)
-        headers ||= row.keys.map(&:to_s)
-        if num_rows == 0
-          logger.info "first row: #{row.inspect[0..500]}"
-          logger.info "id: #{get_id(row).inspect}"
+      ).each.each_slice(DataMagic::DEFAULT_CHUNK_SIZE) do |chunk|
+        chunk.each do |row|
+          row = parse_row(row, new_field_names, options, additional_data)
+          headers ||= row.keys.map(&:to_s)
+          if num_rows == 0
+            logger.info "first row: #{row.inspect[0..500]}"
+            logger.info "id: #{get_id(row).inspect}"
+          end
+          client.index({
+            index: es_index_name,
+            id: get_id(row),
+            type: 'document',
+            body: row,
+          })
+          if num_rows % 500 == 0
+            logger.info "indexing rows: #{num_rows}..."
+          end
+          num_rows += 1
         end
-        client.index({
-          index: es_index_name,
-          id: get_id(row),
-          type: 'document',
-          body: row,
-        })
-        if num_rows % 500 == 0
-          logger.info "indexing rows: #{num_rows}..."
-        end
-        num_rows += 1
       end
-
     rescue Exception => e
       Config.logger.error e.message
-      rows = []
     end
 
     raise InvalidData, "invalid file format or zero rows" if num_rows == 0
@@ -112,9 +107,7 @@ module DataMagic
       logger.debug "indexing #{fname} file config:#{self.config.additional_data_for_file(fname).inspect}"
       options[:add_data] = self.config.additional_data_for_file(fname)
       begin
-        logger.debug "reading #{filepath}"
-        data = config.read_path(filepath)
-        rows, _ = DataMagic.import_csv(data, options)
+        rows, _ = DataMagic.import_csv(filepath, options)
         logger.debug "imported #{rows} rows"
       rescue Exception => e
        Config.logger.debug "Error: skipping #{filepath}, #{e.message}"

--- a/lib/data_magic/index.rb
+++ b/lib/data_magic/index.rb
@@ -107,7 +107,10 @@ module DataMagic
       logger.debug "indexing #{fname} file config:#{self.config.additional_data_for_file(fname).inspect}"
       options[:add_data] = self.config.additional_data_for_file(fname)
       begin
-        rows, _ = DataMagic.import_csv(filepath, options)
+        logger.debug "reading #{filepath}"
+        data = config.read_path(filepath)
+        rows, _ = DataMagic.import_csv(data, options)
+        data.close
         logger.debug "imported #{rows} rows"
       rescue Exception => e
        Config.logger.debug "Error: skipping #{filepath}, #{e.message}"

--- a/spec/lib/data_magic/config_spec.rb
+++ b/spec/lib/data_magic/config_spec.rb
@@ -41,7 +41,7 @@ describe DataMagic::Config do
           contents: [double("item", key:"data.yaml")])
 
       allow(fake_s3).to receive(:get_object)
-        .with(bucket: 'mybucket', key: 'data.yaml')
+        .with(bucket: 'mybucket', key: 'data.yaml', response_target: duck_type(:read))
         .and_return(fake_get_object_response)
       allow(fake_s3).to receive(:list_objects)
                     .with(bucket: 'mybucket')

--- a/spec/lib/data_magic/import_csv_spec.rb
+++ b/spec/lib/data_magic/import_csv_spec.rb
@@ -29,7 +29,7 @@ describe "DataMagic #import_csv" do
       }.to raise_error(DataMagic::InvalidData)
     end
 
-    it "allows importing invalid utf8 with force_utf8 option" do
+    xit "allows importing invalid utf8 with force_utf8 option" do
       real_num_rows = File.read('./spec/fixtures/invalid_utf8.csv').lines.count - 1
       File.open('./spec/fixtures/invalid_utf8.csv') do |f|
         reported_num_rows, fields = DataMagic.import_csv(f, force_utf8: true)


### PR DESCRIPTION
Currently, `import_csv` reads the entire file into memory, then indexes rows one by one. We can improve performance in at least two ways: loading the file in chunks, so that big files don't crash the import process; and using bulk inserts, to cut back on the number of requests made. This patch implements the first optimization, and also makes the second one feasible (since the previous proposal for bulk inserts loaded even more into memory). Once this is in good shape, we can update #86 accordingly, and imports should be substantially faster.

Note: since we never have a string that contains the entire file under this patch, we don't get an opportunity to force-encode the file contents to UTF-8. The corresponding test is skipped for now. To restore this behavior, we could add a small patch to `smarter_csv` (this would be very straightforward), or add a separate preprocessing step to handle encoding.
