### PR TITLE
make API links relative

### DIFF
--- a/app/views/home.liquid
+++ b/app/views/home.liquid
@@ -4,7 +4,7 @@
 
 <ul>
 {% for name in endpoints %}
-  <li><a href="/{{ name }}">{{ name }}</a></li>
+  <li><a href="{{ name }}">{{ name }}</a></li>
 {% endfor %}
 </ul>
 

--- a/sample-data/data.yaml
+++ b/sample-data/data.yaml
@@ -9,12 +9,6 @@ index: city-data
 api: cities
 unique: ['name']
 
-examples:
-- link: cities?state=CA
-  name: Cities in California
-- link: cities?population__range=1000000..
-  name: Cities with 1 million people or more
-
 dictionary:
   state: USPS
   name: NAME

--- a/sample-data/data.yaml
+++ b/sample-data/data.yaml
@@ -8,6 +8,13 @@ version: cities100-2010
 index: city-data
 api: cities
 unique: ['name']
+
+examples:
+- link: cities?state=CA
+  name: Cities in California
+- link: cities?population__range=1000000..
+  name: Cities with 1 million people or more
+
 dictionary:
   state: USPS
   name: NAME


### PR DESCRIPTION
Currently links will only work if hosted at the root of a domain. This PR will make them relative, so that if the app is mounted at a subpath (in our case, proxied via api.data.gov) the links will still work.