### PR TITLE
Initial New Relic setup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,7 @@ gem 'padrino', '0.12.5'
 
 gem 'pry', :group => 'development'
 gem 'pry-byebug', :group => 'development'
+gem 'newrelic_rpm'
 
 # Or Padrino Edge
 # gem 'padrino', :github => 'padrino/padrino-framework'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,6 +98,7 @@ GEM
     multi_json (1.11.2)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
+    newrelic_rpm (3.9.9.275)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
     oauth (0.4.7)
@@ -232,6 +233,7 @@ DEPENDENCIES
   hashie
   liquid (= 3.0.3)
   liquify
+  newrelic_rpm
   padrino (= 0.12.5)
   pry
   pry-byebug

--- a/config/env.rb
+++ b/config/env.rb
@@ -8,6 +8,7 @@ PADRINO_ROOT      = File.expand_path('../..', __FILE__) unless defined?(PADRINO_
 # Load our dependencies
 require 'rubygems' unless defined?(Gem)
 require 'bundler/setup'
+require 'newrelic_rpm'
 Bundler.require(:default, RACK_ENV)
 
 # do this early so we can log during startup


### PR DESCRIPTION
Note: Requires `NEW_RELIC_LICENSE_KEY` and `NEW_RELIC_APP_NAME` env vars set in each environment. The license key is the same each time, but app name will be different (e.g. `CC-API (Dev)`, `CC-API (Staging)` etc.)