### PR TITLE
specify complete mapping to supported full path nested queries

### DIFF
--- a/lib/data_magic.rb
+++ b/lib/data_magic.rb
@@ -104,14 +104,28 @@ module DataMagic
   end
 
   private
+    def self.nested_object_type(hash)
+      hash.each do |key, value|
+       if value.is_a?(Hash) && value[:type].nil?  # things are nested under this
+          value[:path] = "full"
+          value[:type] = "object"
+          nested_object_type(value)
+        end
+      end
+    end
+
     def self.create_index(es_index_name = nil, field_types={})
+      logger.info "create_index field_types: #{field_types.inspect[0..500]}"
       es_index_name ||= self.config.scoped_index_name
       field_types['location'] = 'geo_point'
       es_types = {}
       field_types.each do |key, type|
         es_types[key] = { type: type }
       end
+      es_types = NestedHash.new.add(es_types)
+      nested_object_type(es_types)
       begin
+        logger.info "====> creating index with type mapping: #{es_types.inspect[0..500]}"
         client.indices.create index: es_index_name, body: {
           mappings: {
             document: {    # type 'document' is always used for external indexed docs
@@ -119,7 +133,6 @@ module DataMagic
             }
           }
         }
-        logger.info "====> index created with es type mapping: #{es_types.inspect[0..255]}"
       rescue Elasticsearch::Transport::Transport::Errors::BadRequest => error
         if error.message.include? "IndexAlreadyExistsException"
           logger.debug "create_index failed: #{es_index_name} already exists"

--- a/lib/data_magic.rb
+++ b/lib/data_magic.rb
@@ -15,6 +15,11 @@ require_relative 'data_magic/query_builder'
 
 SafeYAML::OPTIONS[:default_mode] = :safe
 
+class IndifferentHash < Hash
+  include Hashie::Extensions::MergeInitializer
+  include Hashie::Extensions::IndifferentAccess
+end
+
 module DataMagic
 
   class << self
@@ -22,11 +27,6 @@ module DataMagic
     def logger
       Config.logger
     end
-  end
-
-  class IndifferentHash < Hash
-    include Hashie::Extensions::MergeInitializer
-    include Hashie::Extensions::IndifferentAccess
   end
 
   DEFAULT_PAGE_SIZE = 20
@@ -107,8 +107,10 @@ module DataMagic
     def self.nested_object_type(hash)
       hash.each do |key, value|
        if value.is_a?(Hash) && value[:type].nil?  # things are nested under this
-          value[:path] = "full"
-          value[:type] = "object"
+          hash[key] = {
+            path: "full", type: "object",
+            properties: value
+          }
           nested_object_type(value)
         end
       end

--- a/lib/data_magic.rb
+++ b/lib/data_magic.rb
@@ -73,7 +73,7 @@ module DataMagic
     logger.info "FULL_QUERY: #{full_query.inspect}"
 
     result = client.search full_query
-    logger.info "result: #{result.inspect}"
+    logger.info "result: #{result.inspect[0..500]}"
     hits = result["hits"]
     total = hits["total"]
     results = []

--- a/lib/data_magic/config.rb
+++ b/lib/data_magic/config.rb
@@ -102,7 +102,9 @@ module DataMagic
       if @field_types.nil?
         @field_types = {}
         dictionary.each do |field_name, info|
-          type = info['type']
+          type = info['type'] || "string"
+          type = nil if field_name == 'location.lat' || field_name == 'location.lon'
+          logger.info "field #{field_name}: #{type.inspect}"
           @field_types[field_name] = type unless type.nil?
         end
       end
@@ -249,7 +251,7 @@ module DataMagic
         logger.debug "load config #{directory_path.inspect}"
         @data = load_yaml(directory_path)
         @data['unique'] ||= []
-        logger.debug "config: #{@data.inspect[0..255]}"
+        logger.debug "config: #{@data.inspect[0..600]}"
         @data['index'] ||= clean_index(@data_path)
         endpoint = @data['api'] || clean_index(@data_path)
         @dictionary = @data['dictionary'] || {}

--- a/lib/data_magic/config.rb
+++ b/lib/data_magic/config.rb
@@ -65,7 +65,7 @@ module DataMagic
     # fetches file configuration
     # add: whatever
     def additional_data_for_file(index)
-      result = @data.fetch('files', []).fetch(index, {}).fetch('add', nil)
+      @data.fetch('files', []).fetch(index, {}).fetch('add', nil)
     end
 
     def info_for_file(index, field)
@@ -102,17 +102,6 @@ module DataMagic
       end
     end
 
-    # look through the files configuration
-    # pull out all the fields that are specified in
-    # only: [one, two, three]
-    # this means we should only take these fields from that file
-    def only_field_list_orig
-      only = file_config.select { |f| f[:only] }
-      only = only.inject([]) {|all, f| all += f[:only] }
-    end
-
-
-    # look through the files configuration
     # pull out all the fields that are specified in
     # only: [one, two, three]
     # this means we should only take these fields from that file

--- a/lib/data_magic/config.rb
+++ b/lib/data_magic/config.rb
@@ -104,7 +104,7 @@ module DataMagic
         dictionary.each do |field_name, info|
           type = info['type'] || "string"
           type = nil if field_name == 'location.lat' || field_name == 'location.lon'
-          logger.info "field #{field_name}: #{type.inspect}"
+          #logger.info "field #{field_name}: #{type.inspect}"
           @field_types[field_name] = type unless type.nil?
         end
       end

--- a/lib/data_magic/index.rb
+++ b/lib/data_magic/index.rb
@@ -29,6 +29,7 @@ module DataMagic
   # parse a row from a csv file, returns a nested document
   def self.parse_row(row, fields, options, additional)
     row = row.to_hash
+    #logger.info "fields #{fields.inspect}"
     row = map_field_names(row, fields, options) unless fields.empty?
     map_field_types(row, config.field_types) unless config.field_types.empty?
     row = row.merge(additional) if additional
@@ -194,8 +195,8 @@ private
     mapped = {}
     row.each do |key, value|
       raise ArgumentError, "column header missing for: #{value}" if key.nil?
-      #logger.info "key: #{key.inspect}, value:#{value.inspect}"
       new_key = new_fields[key.to_sym] || new_fields[key.to_s]
+      #logger.info "key: #{key.inspect}, new_key:#{new_key.inspect}"
       if new_key
         value = value.to_f if new_key.include? "location"
         mapped[new_key] = value

--- a/lib/data_magic/index.rb
+++ b/lib/data_magic/index.rb
@@ -10,8 +10,7 @@ module DataMagic
     if nest_options
       #logger.info "nest: #{nest_options.to_yaml}"
       #logger.info "add to document: #{document.inspect[0..255]}"
-      key = document[nest_options['key']]
-      #logger.info "year => #{key}"
+      key = nest_options['key']
       new_doc[key] = {}
 
       id = document['id']
@@ -31,7 +30,7 @@ module DataMagic
     row = row.to_hash
     #logger.info "fields #{fields.inspect}"
     row = map_field_names(row, fields, options) unless fields.empty?
-    map_field_types(row, config.field_types) unless config.field_types.empty?
+    map_field_types(row, config.column_field_types) unless config.column_field_types.empty?
     row = row.merge(additional) if additional
     document = NestedHash.new.add(row)
     document = parse_nested(document, options) if options[:nest]

--- a/spec/features/api_spec.rb
+++ b/spec/features/api_spec.rb
@@ -205,4 +205,37 @@ describe 'api', type: 'feature' do
 			expect(first['2013']['earnings']).to eq({"percent_gt_25k"=>0.53, "median"=>26318})
 		end
 	end
+
+	context "with alternate nested data" do
+		before do
+			DataMagic.destroy
+			ENV['DATA_PATH'] = './spec/fixtures/nested2'
+			DataMagic.config = DataMagic::Config.new
+			DataMagic.import_with_dictionary
+		end
+		after do
+			DataMagic.destroy
+		end
+		let(:expected) {
+			{
+				"total" => 1,
+				"page"  => 0,
+				"per_page" => DataMagic::DEFAULT_PAGE_SIZE,
+				"results" => [{"id"=>9, "school"=>{"city"=>"Tanner", "state"=>"AL", "zip"=>35671, "name"=>"Inquisitive Farm College"}}]
+				}
+		}
+		it "can search for nested name" do
+			get '/fakeschool?school.name=Inquisitive Farm'
+			expect(last_response).to be_ok
+			result = JSON.parse(last_response.body)
+			expect(result).to eq(expected)
+		end
+		it "can search for nested number" do
+			get '/fakeschool?school.zip=35671'
+			expect(last_response).to be_ok
+			result = JSON.parse(last_response.body)
+			expect(result).to eq(expected)
+		end
+	end
+
 end

--- a/spec/features/api_spec.rb
+++ b/spec/features/api_spec.rb
@@ -2,290 +2,290 @@ require 'spec_helper'
 require 'fixtures/data.rb'
 
 shared_examples_for "api request" do
-	context "CORS requests" do
-		it "sets the Access-Control-Allow-Origin header to allow CORS from anywhere" do
-			expect(last_response.headers['Access-Control-Allow-Origin']).to eq('*')
-		end
+  context "CORS requests" do
+    it "sets the Access-Control-Allow-Origin header to allow CORS from anywhere" do
+      expect(last_response.headers['Access-Control-Allow-Origin']).to eq('*')
+    end
 
-		it "allows GET HTTP method thru CORS" do
-			allowed_http_methods = last_response.header['Access-Control-Allow-Methods']
-			%w{GET}.each do |method|  # don't expect we'll need: POST PUT DELETE
-				expect(allowed_http_methods).to include(method)
-			end
-		end
-	end
+    it "allows GET HTTP method thru CORS" do
+      allowed_http_methods = last_response.header['Access-Control-Allow-Methods']
+      %w{GET}.each do |method|  # don't expect we'll need: POST PUT DELETE
+        expect(allowed_http_methods).to include(method)
+      end
+    end
+  end
 end
 
 
 describe 'api', type: 'feature' do
-	context 'with sample data' do
-		# app starts up in advance of before :all so for now testing only
-		# with ./sample-data
+  context 'with sample data' do
+    # app starts up in advance of before :all so for now testing only
+    # with ./sample-data
 
-		after(:all) do
-			Stretchy.delete 'test-city-data'
-			#expect(DataMagic.client.indices.get(index: '_all')).to be_empty
-		end
+    after(:all) do
+      Stretchy.delete 'test-city-data'
+      #expect(DataMagic.client.indices.get(index: '_all')).to be_empty
+    end
 
-	  it "loads the endpoint list" do
-	    get "/endpoints"
+    it "loads the endpoint list" do
+      get "/endpoints"
 
-	    expect(last_response).to be_ok
-	    expect(last_response.content_type).to eq('application/json')
+      expect(last_response).to be_ok
+      expect(last_response.content_type).to eq('application/json')
 
-	    result = JSON.parse(last_response.body)
-	    expected = {
-	      'endpoints'=>[
-	        'name'=>'cities',
-	        'url'=>'/cities',
-	      ]
-	    }
-	    expect(result).to eq expected
-	  end
+      result = JSON.parse(last_response.body)
+      expected = {
+        'endpoints'=>[
+          'name'=>'cities',
+          'url'=>'/cities',
+        ]
+      }
+      expect(result).to eq expected
+    end
 
-	  it "raises a 404 on missing endpoints" do
-	    get "/missing"
-	    expect(last_response.status).to eq(404)
-	    expect(last_response.content_type).to eq('application/json')
+    it "raises a 404 on missing endpoints" do
+      get "/missing"
+      expect(last_response.status).to eq(404)
+      expect(last_response.content_type).to eq('application/json')
 
-	    result = JSON.parse(last_response.body)
-	    expected = {
-	      "error"=>404,
-	      "message"=>"missing not found. Available endpoints: cities",
-	    }
-	    expect(result).to eq(expected)
-	  end
+      result = JSON.parse(last_response.body)
+      expected = {
+        "error"=>404,
+        "message"=>"missing not found. Available endpoints: cities",
+      }
+      expect(result).to eq(expected)
+    end
 
-		describe "data description" do
-			before do
-				get '/data.json'
-			end
+    describe "data description" do
+      before do
+        get '/data.json'
+      end
 
-			it_behaves_like "api request"
+      it_behaves_like "api request"
 
-			it "responds with json" do
-				expect(last_response).to be_ok
-				expect(last_response.content_type).to eq('application/json')
-			end
-		end
+      it "responds with json" do
+        expect(last_response).to be_ok
+        expect(last_response.content_type).to eq('application/json')
+      end
+    end
 
-		describe "query" do
-			describe "with one term" do
-				before do
-					get '/cities?name=Chicago'
-				end
+    describe "query" do
+      describe "with one term" do
+        before do
+          get '/cities?name=Chicago'
+        end
 
-				it_behaves_like "api request"
+        it_behaves_like "api request"
 
-				it "responds with json" do
-				  expect(last_response).to be_ok
-					expect(last_response.content_type).to eq('application/json')
+        it "responds with json" do
+          expect(last_response).to be_ok
+          expect(last_response.content_type).to eq('application/json')
 
-					result = JSON.parse(last_response.body)
+          result = JSON.parse(last_response.body)
 
-					expected = {
-						"total" => 1,
-					  "page"  => 0,
-					  "per_page" => DataMagic::DEFAULT_PAGE_SIZE,
-					  "results" => [
-							{"state"=>"IL", "name"=>"Chicago", "population"=>2695598,
-							 "land_area"=>227.635,   # later we'll make this a float
-							 "location"=>{"lat"=>41.837551, "lon"=>-87.681844}}						]
-					}
-					expect(result).to eq(expected)
+          expected = {
+            "total" => 1,
+            "page"  => 0,
+            "per_page" => DataMagic::DEFAULT_PAGE_SIZE,
+            "results" => [
+              {"state"=>"IL", "name"=>"Chicago", "population"=>2695598,
+               "land_area"=>227.635,   # later we'll make this a float
+               "location"=>{"lat"=>41.837551, "lon"=>-87.681844}}            ]
+          }
+          expect(result).to eq(expected)
 
-				end
-			end
-			describe "with options" do
-				it "can return a subset of fields" do
-					get '/cities?state=MA&fields=name,population'
+        end
+      end
+      describe "with options" do
+        it "can return a subset of fields" do
+          get '/cities?state=MA&fields=name,population'
 
-					expect(last_response).to be_ok
-					result = JSON.parse(last_response.body)
+          expect(last_response).to be_ok
+          result = JSON.parse(last_response.body)
 
-					expected = {
-						"total" => 1,
-						"page"  => 0,
-						"per_page" => DataMagic::DEFAULT_PAGE_SIZE,
-						"results" => [{"name"=>"Boston", "population"=>617594}]
-					}
-					expect(result).to eq(expected)
+          expected = {
+            "total" => 1,
+            "page"  => 0,
+            "per_page" => DataMagic::DEFAULT_PAGE_SIZE,
+            "results" => [{"name"=>"Boston", "population"=>617594}]
+          }
+          expect(result).to eq(expected)
 
-				end
+        end
 
-			end
+      end
 
-			describe "with float" do
-				before do
-					get '/cities?land_area=302.643'
-				end
+      describe "with float" do
+        before do
+          get '/cities?land_area=302.643'
+        end
 
-				it "responds with json" do
-				  expect(last_response).to be_ok
-					expect(last_response.content_type).to eq('application/json')
+        it "responds with json" do
+          expect(last_response).to be_ok
+          expect(last_response.content_type).to eq('application/json')
 
-					result = JSON.parse(last_response.body)
+          result = JSON.parse(last_response.body)
 
-					expected = {
-						"total" => 1,
-					  "page"  => 0,
-					  "per_page" => DataMagic::DEFAULT_PAGE_SIZE,
-					  "results" => [{"state"=>"NY", "name"=>"New York",
-							"population"=>8175133, "land_area"=>302.643,
-							"location"=>{"lat"=>40.664274, "lon"=>-73.9385}}]
-						}
-					expect(result).to eq(expected)
+          expected = {
+            "total" => 1,
+            "page"  => 0,
+            "per_page" => DataMagic::DEFAULT_PAGE_SIZE,
+            "results" => [{"state"=>"NY", "name"=>"New York",
+              "population"=>8175133, "land_area"=>302.643,
+              "location"=>{"lat"=>40.664274, "lon"=>-73.9385}}]
+            }
+          expect(result).to eq(expected)
 
-				end
+        end
 
-			end
-			describe "near zipcode" do
-				before do
-					get '/cities?zip=94132&distance=30mi'
-					# why isn't SF, 30 miles from SFO... maybe origin point is not
-					# where I expect
-				end
+      end
+      describe "near zipcode" do
+        before do
+          get '/cities?zip=94132&distance=30mi'
+          # why isn't SF, 30 miles from SFO... maybe origin point is not
+          # where I expect
+        end
 
-				it "can find an attribute from an imported file" do
-					expect(last_response).to be_ok
-					result = JSON.parse(last_response.body)
-					result["results"] = result["results"].sort_by { |k| k["name"] }
+        it "can find an attribute from an imported file" do
+          expect(last_response).to be_ok
+          result = JSON.parse(last_response.body)
+          result["results"] = result["results"].sort_by { |k| k["name"] }
 
-					expected = {
-					  "total" => 2,
-					  "page"  => 0,
-					  "per_page" => DataMagic::DEFAULT_PAGE_SIZE,
-					  "results" => [
-							{"state"=>"CA", "name"=>"Fremont", "population"=>214089, "land_area"=>77.459, "location"=>{"lat"=>37.494373, "lon"=>-121.941117}},
-							{"state"=>"CA", "name"=>"Oakland", "population"=>390724, "land_area"=>55.786, "location"=>{"lat"=>37.769857, "lon"=>-122.22564}}]
-					}
-					expect(result).to eq(expected)
-				end
-			end
+          expected = {
+            "total" => 2,
+            "page"  => 0,
+            "per_page" => DataMagic::DEFAULT_PAGE_SIZE,
+            "results" => [
+              {"state"=>"CA", "name"=>"Fremont", "population"=>214089, "land_area"=>77.459, "location"=>{"lat"=>37.494373, "lon"=>-121.941117}},
+              {"state"=>"CA", "name"=>"Oakland", "population"=>390724, "land_area"=>55.786, "location"=>{"lat"=>37.769857, "lon"=>-122.22564}}]
+          }
+          expect(result).to eq(expected)
+        end
+      end
 
-			describe "with sort" do
-				it "can sort numbers ascending" do
-					get '/cities?sort=population:asc'
-					expect(last_response).to be_ok
-					response = JSON.parse(last_response.body)
-					expect(response["results"][0]['name']).to eq("Rochester")
+      describe "with sort" do
+        it "can sort numbers ascending" do
+          get '/cities?sort=population:asc'
+          expect(last_response).to be_ok
+          response = JSON.parse(last_response.body)
+          expect(response["results"][0]['name']).to eq("Rochester")
 
-				end
+        end
 
 
-			end
-		end
-	end
+      end
+    end
+  end
 
-	context "with nested data" do
-		before do
-			DataMagic.destroy
-			ENV['DATA_PATH'] = './spec/fixtures/nested_files'
-			DataMagic.config = DataMagic::Config.new
-	    DataMagic.import_with_dictionary
-		end
-		after do
-			DataMagic.destroy
-		end
-		let(:expected) {
-			{
-				"total" => 1,
-				"page"  => 0,
-				"per_page" => DataMagic::DEFAULT_PAGE_SIZE,
-				"results" => [{"id"=>"9", "city"=>"Tanner", "state"=>"AL",
-					"name"=>"Inquisitive Farm College",
-					"2013"=>{"earnings"=>
-										{"6_yrs_after_entry"=>
-												{"percent_gt_25k"=>0.19, "median"=>34183}},
-									 "sat_average"=>"971"},
-					"2012"=>{"earnings"=>
-										{"6_yrs_after_entry"=>
-												{"percent_gt_25k"=>0.83, "median"=>42150}},
-					"sat_average"=>"1292"}}]
-				}
-		}
-		it "can search" do
-			get '/school?name=Inquisitive Farm'
-			expect(last_response).to be_ok
-			result = JSON.parse(last_response.body)
-			expect(result).to eq(expected)
-		end
-		it "can search for nested number" do
-			get '/school?2013.earnings.6_yrs_after_entry.median=34183'
-			expect(last_response).to be_ok
-			result = JSON.parse(last_response.body)
-			expect(result).to eq(expected)
-		end
+  context "with nested data" do
+    before do
+      DataMagic.destroy
+      ENV['DATA_PATH'] = './spec/fixtures/nested_files'
+      DataMagic.config = DataMagic::Config.new
+      DataMagic.import_with_dictionary
+    end
+    after do
+      DataMagic.destroy
+    end
+    let(:expected) {
+      {
+        "total" => 1,
+        "page"  => 0,
+        "per_page" => DataMagic::DEFAULT_PAGE_SIZE,
+        "results" => [{"id"=>"9", "city"=>"Tanner", "state"=>"AL",
+          "name"=>"Inquisitive Farm College",
+          "2013"=>{"earnings"=>
+                    {"6_yrs_after_entry"=>
+                        {"percent_gt_25k"=>0.19, "median"=>34183}},
+                   "sat_average"=>"971"},
+          "2012"=>{"earnings"=>
+                    {"6_yrs_after_entry"=>
+                        {"percent_gt_25k"=>0.83, "median"=>42150}},
+          "sat_average"=>"1292"}}]
+        }
+    }
+    it "can search" do
+      get '/school?name=Inquisitive Farm'
+      expect(last_response).to be_ok
+      result = JSON.parse(last_response.body)
+      expect(result).to eq(expected)
+    end
+    it "can search for nested number" do
+      get '/school?2013.earnings.6_yrs_after_entry.median=34183'
+      expect(last_response).to be_ok
+      result = JSON.parse(last_response.body)
+      expect(result).to eq(expected)
+    end
 
-		it "can search for nested float" do
-			get '/school?2013.earnings.6_yrs_after_entry.percent_gt_25k=0.19'
-			expect(last_response).to be_ok
-			result = JSON.parse(last_response.body)
-			expect(result).to eq(expected)
-		end
+    it "can search for nested float" do
+      get '/school?2013.earnings.6_yrs_after_entry.percent_gt_25k=0.19'
+      expect(last_response).to be_ok
+      result = JSON.parse(last_response.body)
+      expect(result).to eq(expected)
+    end
 
-		it "can search for range" do
-			get '/school?2013.earnings.6_yrs_after_entry.median__range=49310..'
-			expect(last_response).to be_ok
-			result = JSON.parse(last_response.body)
-			expected["results"] = [
-				{"id"=>"8", "city"=>"Birmingham", "state"=>"AL",
-						"name"=>"Condemned Balloon Institute",
-						"2013"=>{"earnings"=>
-											{"6_yrs_after_entry"=>
-												{"percent_gt_25k"=>0.59, "median"=>59759}},
-									   "sat_average"=>"616"},
-						"2012"=>{"earnings"=>
-											{"6_yrs_after_entry"=>
-													{"percent_gt_25k"=>0.97, "median"=>30063}},
-						         "sat_average"=>"1420"}}]
-			expect(result).to eq(expected)
-		end
-	end
+    it "can search for range" do
+      get '/school?2013.earnings.6_yrs_after_entry.median__range=49310..'
+      expect(last_response).to be_ok
+      result = JSON.parse(last_response.body)
+      expected["results"] = [
+        {"id"=>"8", "city"=>"Birmingham", "state"=>"AL",
+            "name"=>"Condemned Balloon Institute",
+            "2013"=>{"earnings"=>
+                      {"6_yrs_after_entry"=>
+                        {"percent_gt_25k"=>0.59, "median"=>59759}},
+                     "sat_average"=>"616"},
+            "2012"=>{"earnings"=>
+                      {"6_yrs_after_entry"=>
+                          {"percent_gt_25k"=>0.97, "median"=>30063}},
+                     "sat_average"=>"1420"}}]
+      expect(result).to eq(expected)
+    end
+  end
 
-	context "with alternate nested data" do
-		before do
-			DataMagic.destroy
-			ENV['DATA_PATH'] = './spec/fixtures/nested2'
-			DataMagic.config = DataMagic::Config.new
-			DataMagic.import_with_dictionary
-		end
-		after do
-			DataMagic.destroy
-		end
-		let(:expected) {
-			{
-				"total" => 1,
-				"page"  => 0,
-				"per_page" => DataMagic::DEFAULT_PAGE_SIZE,
-				"results" => [{"id"=>9, "school"=>{"city"=>"Tanner", "state"=>"AL", "zip"=>35671, "name"=>"Inquisitive Farm College"}}]
-				}
-		}
-		it "can search for nested name" do
-			get '/fakeschool?school.name=Inquisitive Farm'
-			expect(last_response).to be_ok
-			result = JSON.parse(last_response.body)
-			expect(result).to eq(expected)
-		end
-		it "can search for nested number" do
-			get '/fakeschool?school.zip=35671'
-			expect(last_response).to be_ok
-			result = JSON.parse(last_response.body)
-			expect(result).to eq(expected)
-		end
-		it "can search for range" do
-			get '/fakeschool?school.zip__range=36800..'
-			expect(last_response).to be_ok
-			result = JSON.parse(last_response.body)
-			expected["results"] = [
-				{"id"=>7,
-				 "school"=>{"city"=>"Auburn University",
-					 	 "state"=>"AL", "zip"=>36849,
-						 "name"=>"Alabama Beauty College of Auburn University"}
-				 }
-			]
-			expect(result).to eq(expected)
-		end
-	end
+  context "with alternate nested data" do
+    before do
+      DataMagic.destroy
+      ENV['DATA_PATH'] = './spec/fixtures/nested2'
+      DataMagic.config = DataMagic::Config.new
+      DataMagic.import_with_dictionary
+    end
+    after do
+      DataMagic.destroy
+    end
+    let(:expected) {
+      {
+        "total" => 1,
+        "page"  => 0,
+        "per_page" => DataMagic::DEFAULT_PAGE_SIZE,
+        "results" => [{"id"=>9, "school"=>{"city"=>"Tanner", "state"=>"AL", "zip"=>35671, "name"=>"Inquisitive Farm College"}}]
+        }
+    }
+    it "can search for nested name" do
+      get '/fakeschool?school.name=Inquisitive Farm'
+      expect(last_response).to be_ok
+      result = JSON.parse(last_response.body)
+      expect(result).to eq(expected)
+    end
+    it "can search for nested number" do
+      get '/fakeschool?school.zip=35671'
+      expect(last_response).to be_ok
+      result = JSON.parse(last_response.body)
+      expect(result).to eq(expected)
+    end
+    it "can search for range" do
+      get '/fakeschool?school.zip__range=36800..'
+      expect(last_response).to be_ok
+      result = JSON.parse(last_response.body)
+      expected["results"] = [
+        {"id"=>7,
+         "school"=>{"city"=>"Auburn University",
+              "state"=>"AL", "zip"=>36849,
+             "name"=>"Alabama Beauty College of Auburn University"}
+         }
+      ]
+      expect(result).to eq(expected)
+    end
+  end
 
 end

--- a/spec/features/api_spec.rb
+++ b/spec/features/api_spec.rb
@@ -187,39 +187,58 @@ describe 'api', type: 'feature' do
 		after do
 			DataMagic.destroy
 		end
-
+		let(:expected) {
+			{
+				"total" => 1,
+				"page"  => 0,
+				"per_page" => DataMagic::DEFAULT_PAGE_SIZE,
+				"results" => [{"id"=>"9", "city"=>"Tanner", "state"=>"AL",
+					"name"=>"Inquisitive Farm College",
+					"2013"=>{"earnings"=>
+										{"6_yrs_after_entry"=>
+												{"percent_gt_25k"=>0.19, "median"=>34183}},
+									 "sat_average"=>"971"},
+					"2012"=>{"earnings"=>
+										{"6_yrs_after_entry"=>
+												{"percent_gt_25k"=>0.83, "median"=>42150}},
+					"sat_average"=>"1292"}}]
+				}
+		}
 		it "can search" do
 			get '/school?name=Inquisitive Farm'
 			expect(last_response).to be_ok
 			result = JSON.parse(last_response.body)
-			expect(result["total"]).to eq(1)
-			first = result["results"].first
-			expect(first["name"]).to eq("Inquisitive Farm College")
+			expect(result).to eq(expected)
 		end
 		it "can search for nested number" do
-			get '/school?2013.earnings.median=26318'
+			get '/school?2013.earnings.6_yrs_after_entry.median=34183'
 			expect(last_response).to be_ok
 			result = JSON.parse(last_response.body)
-			expect(result["total"]).to eq(1)
-			first = result["results"].first
-			expect(first['2013']['earnings']).to eq({"percent_gt_25k"=>0.53, "median"=>26318})
+			expect(result).to eq(expected)
+		end
+
+		it "can search for nested float" do
+			get '/school?earnings.6_yrs_after_entry.percent_gt_25k=0.19'
+			expect(last_response).to be_ok
+			result = JSON.parse(last_response.body)
+			expect(result).to eq(expected)
 		end
 
 		it "can search for range" do
-			get '/school?2013.earnings.median__range=49310..'
+			get '/school?2013.earnings.6_yrs_after_entry.median__range=49310..'
 			expect(last_response).to be_ok
 			result = JSON.parse(last_response.body)
-			expected = {
-					"total" => 1,
-					"page"  => 0,
-					"per_page" => DataMagic::DEFAULT_PAGE_SIZE,
-					"results" => [{"id"=>"8", "city"=>"Birmingham", "state"=>"AL",
+			expected["results"] = [
+				{"id"=>"8", "city"=>"Birmingham", "state"=>"AL",
 						"name"=>"Condemned Balloon Institute",
-						"2013"=>{"earnings"=>{"percent_gt_25k"=>0.59, "median"=>59759}, 
+						"2013"=>{"earnings"=>
+											{"6_yrs_after_entry"=>
+												{"percent_gt_25k"=>0.59, "median"=>59759}},
 									   "sat_average"=>"616"},
-						"2012"=>{"earnings"=>{"percent_gt_25k"=>0.97, "median"=>30063},
+						"2012"=>{"earnings"=>
+											{"6_yrs_after_entry"=>
+													{"percent_gt_25k"=>0.97, "median"=>30063}},
 						         "sat_average"=>"1420"}}]
-			}
 			expect(result).to eq(expected)
 		end
 	end

--- a/spec/features/api_spec.rb
+++ b/spec/features/api_spec.rb
@@ -18,161 +18,191 @@ end
 
 
 describe 'api', type: 'feature' do
-	# app starts up in advance of before :all so for now testing only
-	# with ./sample-data
+	context 'with sample data' do
+		# app starts up in advance of before :all so for now testing only
+		# with ./sample-data
 
-	after(:all) do
-		Stretchy.delete 'test-city-data'
-		#expect(DataMagic.client.indices.get(index: '_all')).to be_empty
-	end
-
-  it "loads the endpoint list" do
-    get "/endpoints"
-
-    expect(last_response).to be_ok
-    expect(last_response.content_type).to eq('application/json')
-
-    result = JSON.parse(last_response.body)
-    expected = {
-      'endpoints'=>[
-        'name'=>'cities',
-        'url'=>'/cities',
-      ]
-    }
-    expect(result).to eq expected
-  end
-
-  it "raises a 404 on missing endpoints" do
-    get "/missing"
-    expect(last_response.status).to eq(404)
-    expect(last_response.content_type).to eq('application/json')
-
-    result = JSON.parse(last_response.body)
-    expected = {
-      "error"=>404,
-      "message"=>"missing not found. Available endpoints: cities",
-    }
-    expect(result).to eq(expected)
-  end
-
-	describe "data description" do
-		before do
-			get '/data.json'
+		after(:all) do
+			Stretchy.delete 'test-city-data'
+			#expect(DataMagic.client.indices.get(index: '_all')).to be_empty
 		end
 
-		it_behaves_like "api request"
+	  it "loads the endpoint list" do
+	    get "/endpoints"
 
-		it "responds with json" do
-			expect(last_response).to be_ok
-			expect(last_response.content_type).to eq('application/json')
-		end
-	end
+	    expect(last_response).to be_ok
+	    expect(last_response.content_type).to eq('application/json')
 
-	describe "query" do
-		describe "with one term" do
+	    result = JSON.parse(last_response.body)
+	    expected = {
+	      'endpoints'=>[
+	        'name'=>'cities',
+	        'url'=>'/cities',
+	      ]
+	    }
+	    expect(result).to eq expected
+	  end
+
+	  it "raises a 404 on missing endpoints" do
+	    get "/missing"
+	    expect(last_response.status).to eq(404)
+	    expect(last_response.content_type).to eq('application/json')
+
+	    result = JSON.parse(last_response.body)
+	    expected = {
+	      "error"=>404,
+	      "message"=>"missing not found. Available endpoints: cities",
+	    }
+	    expect(result).to eq(expected)
+	  end
+
+		describe "data description" do
 			before do
-				get '/cities?name=Chicago'
+				get '/data.json'
 			end
 
 			it_behaves_like "api request"
 
 			it "responds with json" do
-			  expect(last_response).to be_ok
-				expect(last_response.content_type).to eq('application/json')
-
-				result = JSON.parse(last_response.body)
-
-				expected = {
-					"total" => 1,
-				  "page"  => 0,
-				  "per_page" => DataMagic::DEFAULT_PAGE_SIZE,
-				  "results" => [
-						{"state"=>"IL", "name"=>"Chicago", "population"=>2695598,
-						 "land_area"=>227.635,   # later we'll make this a float
-						 "location"=>{"lat"=>41.837551, "lon"=>-87.681844}}						]
-				}
-				expect(result).to eq(expected)
-
-			end
-		end
-		describe "with options" do
-			it "can return a subset of fields" do
-				get '/cities?state=MA&fields=name,population'
-
 				expect(last_response).to be_ok
-				result = JSON.parse(last_response.body)
-
-				expected = {
-					"total" => 1,
-					"page"  => 0,
-					"per_page" => DataMagic::DEFAULT_PAGE_SIZE,
-					"results" => [{"name"=>"Boston", "population"=>617594}]
-				}
-				expect(result).to eq(expected)
-
+				expect(last_response.content_type).to eq('application/json')
 			end
-
 		end
 
-		describe "with float" do
-			before do
-				get '/cities?land_area=302.643'
-			end
+		describe "query" do
+			describe "with one term" do
+				before do
+					get '/cities?name=Chicago'
+				end
 
-			it "responds with json" do
-			  expect(last_response).to be_ok
-				expect(last_response.content_type).to eq('application/json')
+				it_behaves_like "api request"
 
-				result = JSON.parse(last_response.body)
+				it "responds with json" do
+				  expect(last_response).to be_ok
+					expect(last_response.content_type).to eq('application/json')
 
-				expected = {
-					"total" => 1,
-				  "page"  => 0,
-				  "per_page" => DataMagic::DEFAULT_PAGE_SIZE,
-				  "results" => [{"state"=>"NY", "name"=>"New York",
-						"population"=>8175133, "land_area"=>302.643,
-						"location"=>{"lat"=>40.664274, "lon"=>-73.9385}}]
+					result = JSON.parse(last_response.body)
+
+					expected = {
+						"total" => 1,
+					  "page"  => 0,
+					  "per_page" => DataMagic::DEFAULT_PAGE_SIZE,
+					  "results" => [
+							{"state"=>"IL", "name"=>"Chicago", "population"=>2695598,
+							 "land_area"=>227.635,   # later we'll make this a float
+							 "location"=>{"lat"=>41.837551, "lon"=>-87.681844}}						]
 					}
-				expect(result).to eq(expected)
+					expect(result).to eq(expected)
+
+				end
+			end
+			describe "with options" do
+				it "can return a subset of fields" do
+					get '/cities?state=MA&fields=name,population'
+
+					expect(last_response).to be_ok
+					result = JSON.parse(last_response.body)
+
+					expected = {
+						"total" => 1,
+						"page"  => 0,
+						"per_page" => DataMagic::DEFAULT_PAGE_SIZE,
+						"results" => [{"name"=>"Boston", "population"=>617594}]
+					}
+					expect(result).to eq(expected)
+
+				end
 
 			end
 
-		end
-		describe "near zipcode" do
-			before do
-				get '/cities?zip=94132&distance=30mi'
-				# why isn't SF, 30 miles from SFO... maybe origin point is not
-				# where I expect
-			end
+			describe "with float" do
+				before do
+					get '/cities?land_area=302.643'
+				end
 
-			it "can find an attribute from an imported file" do
-				expect(last_response).to be_ok
-				result = JSON.parse(last_response.body)
-				result["results"] = result["results"].sort_by { |k| k["name"] }
+				it "responds with json" do
+				  expect(last_response).to be_ok
+					expect(last_response.content_type).to eq('application/json')
 
-				expected = {
-				  "total" => 2,
-				  "page"  => 0,
-				  "per_page" => DataMagic::DEFAULT_PAGE_SIZE,
-				  "results" => [
-						{"state"=>"CA", "name"=>"Fremont", "population"=>214089, "land_area"=>77.459, "location"=>{"lat"=>37.494373, "lon"=>-121.941117}},
-						{"state"=>"CA", "name"=>"Oakland", "population"=>390724, "land_area"=>55.786, "location"=>{"lat"=>37.769857, "lon"=>-122.22564}}]
-				}
-				expect(result).to eq(expected)
-			end
-		end
+					result = JSON.parse(last_response.body)
 
-		describe "with sort" do
-			it "can sort numbers ascending" do
-				get '/cities?sort=population:asc'
-				expect(last_response).to be_ok
-				response = JSON.parse(last_response.body)
-				expect(response["results"][0]['name']).to eq("Rochester")
+					expected = {
+						"total" => 1,
+					  "page"  => 0,
+					  "per_page" => DataMagic::DEFAULT_PAGE_SIZE,
+					  "results" => [{"state"=>"NY", "name"=>"New York",
+							"population"=>8175133, "land_area"=>302.643,
+							"location"=>{"lat"=>40.664274, "lon"=>-73.9385}}]
+						}
+					expect(result).to eq(expected)
+
+				end
 
 			end
+			describe "near zipcode" do
+				before do
+					get '/cities?zip=94132&distance=30mi'
+					# why isn't SF, 30 miles from SFO... maybe origin point is not
+					# where I expect
+				end
+
+				it "can find an attribute from an imported file" do
+					expect(last_response).to be_ok
+					result = JSON.parse(last_response.body)
+					result["results"] = result["results"].sort_by { |k| k["name"] }
+
+					expected = {
+					  "total" => 2,
+					  "page"  => 0,
+					  "per_page" => DataMagic::DEFAULT_PAGE_SIZE,
+					  "results" => [
+							{"state"=>"CA", "name"=>"Fremont", "population"=>214089, "land_area"=>77.459, "location"=>{"lat"=>37.494373, "lon"=>-121.941117}},
+							{"state"=>"CA", "name"=>"Oakland", "population"=>390724, "land_area"=>55.786, "location"=>{"lat"=>37.769857, "lon"=>-122.22564}}]
+					}
+					expect(result).to eq(expected)
+				end
+			end
+
+			describe "with sort" do
+				it "can sort numbers ascending" do
+					get '/cities?sort=population:asc'
+					expect(last_response).to be_ok
+					response = JSON.parse(last_response.body)
+					expect(response["results"][0]['name']).to eq("Rochester")
+
+				end
 
 
+			end
 		end
 	end
 
+	context "with nested data" do
+		before do
+			DataMagic.destroy
+			ENV['DATA_PATH'] = './spec/fixtures/nested_files'
+			DataMagic.config = DataMagic::Config.new
+	    DataMagic.import_with_dictionary
+		end
+		after do
+			DataMagic.destroy
+		end
+
+		it "can search" do
+			get '/school?name=Inquisitive Farm'
+			expect(last_response).to be_ok
+			result = JSON.parse(last_response.body)
+			expect(result["total"]).to eq(1)
+			first = result["results"].first
+			expect(first["name"]).to eq("Inquisitive Farm College")
+		end
+		it "can search for nested number" do
+			get '/school?2013.earnings.median=26318'
+			expect(last_response).to be_ok
+			result = JSON.parse(last_response.body)
+			expect(result["total"]).to eq(1)
+			first = result["results"].first
+			expect(first['2013']['earnings']).to eq({"percent_gt_25k"=>0.53, "median"=>26318})
+		end
+	end
 end

--- a/spec/features/api_spec.rb
+++ b/spec/features/api_spec.rb
@@ -218,7 +218,7 @@ describe 'api', type: 'feature' do
 		end
 
 		it "can search for nested float" do
-			get '/school?earnings.6_yrs_after_entry.percent_gt_25k=0.19'
+			get '/school?2013.earnings.6_yrs_after_entry.percent_gt_25k=0.19'
 			expect(last_response).to be_ok
 			result = JSON.parse(last_response.body)
 			expect(result).to eq(expected)

--- a/spec/features/api_spec.rb
+++ b/spec/features/api_spec.rb
@@ -204,6 +204,24 @@ describe 'api', type: 'feature' do
 			first = result["results"].first
 			expect(first['2013']['earnings']).to eq({"percent_gt_25k"=>0.53, "median"=>26318})
 		end
+
+		it "can search for range" do
+			get '/school?2013.earnings.median__range=49310..'
+			expect(last_response).to be_ok
+			result = JSON.parse(last_response.body)
+			expected = {
+					"total" => 1,
+					"page"  => 0,
+					"per_page" => DataMagic::DEFAULT_PAGE_SIZE,
+					"results" => [{"id"=>"8", "city"=>"Birmingham", "state"=>"AL",
+						"name"=>"Condemned Balloon Institute",
+						"2013"=>{"earnings"=>{"percent_gt_25k"=>0.59, "median"=>59759}, 
+									   "sat_average"=>"616"},
+						"2012"=>{"earnings"=>{"percent_gt_25k"=>0.97, "median"=>30063},
+						         "sat_average"=>"1420"}}]
+			}
+			expect(result).to eq(expected)
+		end
 	end
 
 	context "with alternate nested data" do
@@ -234,6 +252,19 @@ describe 'api', type: 'feature' do
 			get '/fakeschool?school.zip=35671'
 			expect(last_response).to be_ok
 			result = JSON.parse(last_response.body)
+			expect(result).to eq(expected)
+		end
+		it "can search for range" do
+			get '/fakeschool?school.zip__range=36800..'
+			expect(last_response).to be_ok
+			result = JSON.parse(last_response.body)
+			expected["results"] = [
+				{"id"=>7,
+				 "school"=>{"city"=>"Auburn University",
+					 	 "state"=>"AL", "zip"=>36849,
+						 "name"=>"Alabama Beauty College of Auburn University"}
+				 }
+			]
 			expect(result).to eq(expected)
 		end
 	end

--- a/spec/fixtures/nested2/data.yaml
+++ b/spec/fixtures/nested2/data.yaml
@@ -1,0 +1,40 @@
+---
+version: Aug6-2015-08-10-23:48-0600
+api: fakeschool
+index: fakeschool-data
+unique:
+- id
+options:
+#  columns: all
+  limit_files: 1
+  limit_rows: 100
+
+dictionary:
+  id:
+    source: UNITID
+    type: integer
+    description: Unit ID for institution
+  ope8_id:
+    source: OPEID
+    type: integer
+    description: 8-digit OPE ID for institution
+  ope6_id:
+    source: opeid6
+    type: integer
+    description: 6-digit OPE ID for institution
+  school.name:
+    source: INSTNM
+    description: Institution name
+  school.city:
+    source: CITY_MAIN
+    description: City
+  school.state:
+    source: STABBR_MAIN
+    description: State postcode
+  school.zip:
+    source: ZIP_MAIN
+    type: integer
+    description: ZIP code
+
+files:
+  - name: school2013.csv

--- a/spec/fixtures/nested2/school2013.csv
+++ b/spec/fixtures/nested2/school2013.csv
@@ -1,0 +1,11 @@
+UNITID,CITY_MAIN,STABBR_MAIN,ST_FIPS_MAIN,ZIP_MAIN,REGION_MAIN,LATITUDE_MAIN,LONGITUDE_MAIN,INSTNM,SAT_AVG,earn_2002_p10,gt_25k_2006_p6
+1,Normal,AL,1,35762,5,34.7834,-86.5685,Reichert University,1195,26318,0.53
+2,Montgomery,AL,1,36109-3378,5,32.3842,-86.2164,Montgomery School,770,6785,0.61
+3,Montevallo,AL,1,35115-6000,5,33.1063,-86.8651,Indigo Card Community College,526,16767,0.50
+4,Montgomery,AL,1,36104-0271,5,32.3643,-86.2957,Warm Meadow School of Fine Art,457,1836,0.09
+5,Alexander City,AL,1,35010,5,32.9244,-85.9465,Kovacek Institute of Technology,1511,19372,0.82
+6,Athens,AL,1,35611,5,34.8056,-86.9651,Athens Institute,1057,49203,0.06
+7,Auburn University,AL,1,36849,5,32.6002,-85.4924,Alabama Beauty College of Auburn University,486,44097,0.50
+8,Birmingham,AL,1,35254,5,33.5155,-86.8536,Condemned Balloon Institute,616,59759,0.59
+9,Tanner,AL,1,35671,5,34.6543,-86.9491,Inquisitive Farm College,971,34183,0.19
+10,Enterprise,AL,1,36330-1300,5,31.2975,-85.837,Enterprise University,920,42629,0.59

--- a/spec/fixtures/nested_files/data.yaml
+++ b/spec/fixtures/nested_files/data.yaml
@@ -27,14 +27,10 @@ files:
   - name: school-data.csv
     only: [id, name, city, state]
   - name: school2013.csv
-    add:
-      year: 2013
     nest:
-      key: year
+      key: 2013
       contents: [earnings, sat_average]
   - name: school2012.csv
-    add:
-      year: 2012
     nest:
-      key: year
+      key: 2012
       contents: [earnings, sat_average]

--- a/spec/fixtures/nested_files/data.yaml
+++ b/spec/fixtures/nested_files/data.yaml
@@ -13,16 +13,15 @@ dictionary:
   location.lat: LATITUDE_MAIN
   location.lon: LONGITUDE_MAIN
 
-  earnings.median:
+  earnings.6_yrs_after_entry.median:
     source: earn_2002_p10
     description: Median earnings of students
     type: integer
 
-  earnings.percent_gt_25k:
+  earnings.6_yrs_after_entry.percent_gt_25k:
     source: gt_25k_2006_p6
     description: Share of students earning over $25,000/year
     type: float
-
 
 files:
   - name: school-data.csv

--- a/spec/lib/data_magic/config_field_types_spec.rb
+++ b/spec/lib/data_magic/config_field_types_spec.rb
@@ -2,11 +2,11 @@ require 'spec_helper'
 
 describe 'DataMagic::Config #field_types' do
   let(:config) { DataMagic::Config.new(load_datayaml: false) }
+
   it "returns empty if dictionary is empty" do
     allow(config).to receive(:file_config).and_return([{'name' => 'one.csv'}])
     allow(config).to receive(:dictionary).and_return({})
     expect(config.field_types).to eq({})
-
   end
 
   context "when no type is given" do
@@ -16,21 +16,21 @@ describe 'DataMagic::Config #field_types' do
           'name' => {source:'NAME_COLUMN'}
       })
     end
+
     it "defaults to string" do
       expect(config.field_types).to eq({
           'name' => 'string'
       })
     end
   end
+
   it "supports integers" do
     allow(config).to receive(:file_config).and_return([{'name' => 'one.csv'}])
     allow(config).to receive(:dictionary).and_return(
       IndifferentHash.new count:
         {source:'COUNT_COLUMN', type: 'integer'}
     )
-    expect(config.field_types).to eq({
-        'count' => 'integer'
-    })
+    expect(config.field_types).to eq({'count' => 'integer'})
   end
 
   context "with float type" do
@@ -40,24 +40,20 @@ describe 'DataMagic::Config #field_types' do
         IndifferentHash.new percent:
            {source:'PERCENT_COLUMN', type: 'float'}
       )
-      expect(config.field_types).to eq({
-          'percent' => 'float'
-      })
+      expect(config.field_types).to eq({'percent' => 'float'})
     end
+
     it "can be excluded" do
       allow(config).to receive(:dictionary).and_return(
         IndifferentHash.new id: {source:'ID', type: 'integer'},
           percent: {source:'PERCENT', type: 'float'}
       )
       allow(config).to receive(:file_config).and_return([
-        IndifferentHash.new({name:'one.csv',
-            only: ['id']})
+        IndifferentHash.new({ name:'one.csv', only: ['id'] })
       ])
-      expect(config.field_types).to eq({
-          'id' => 'integer'
-      })
-
+      expect(config.field_types).to eq({'id' => 'integer'})
     end
+
     it "can be nested" do
       allow(config).to receive(:dictionary).and_return(
         IndifferentHash.new id: {source:'ID', type: 'integer'},
@@ -73,23 +69,16 @@ describe 'DataMagic::Config #field_types' do
           'id' => 'integer',
           '2012.percent' => 'float'
       })
-
     end
-
-
   end
 
   it "supports special case for location fields as nil" do
+    # special case for location in create_index
     allow(config).to receive(:dictionary).and_return(
       IndifferentHash.new 'location.lat': {source:'LAT_COLUMN'},
                           'location.lon': {source:'LON_COLUMN'}
 
     )
-    expect(config.field_types).to eq({
-      # special case for location in create_index
-    })
+    expect(config.field_types).to eq({})
   end
-
-
-
 end

--- a/spec/lib/data_magic/config_field_types_spec.rb
+++ b/spec/lib/data_magic/config_field_types_spec.rb
@@ -1,0 +1,95 @@
+require 'spec_helper'
+
+describe 'DataMagic::Config #field_types' do
+  let(:config) { DataMagic::Config.new(load_datayaml: false) }
+  it "returns empty if dictionary is empty" do
+    allow(config).to receive(:file_config).and_return([{'name' => 'one.csv'}])
+    allow(config).to receive(:dictionary).and_return({})
+    expect(config.field_types).to eq({})
+
+  end
+
+  context "when no type is given" do
+    before do
+      allow(config).to receive(:file_config).and_return([{'name' => 'one.csv'}])
+      allow(config).to receive(:dictionary).and_return({
+          'name' => {source:'NAME_COLUMN'}
+      })
+    end
+    it "defaults to string" do
+      expect(config.field_types).to eq({
+          'name' => 'string'
+      })
+    end
+  end
+  it "supports integers" do
+    allow(config).to receive(:file_config).and_return([{'name' => 'one.csv'}])
+    allow(config).to receive(:dictionary).and_return(
+      IndifferentHash.new count:
+        {source:'COUNT_COLUMN', type: 'integer'}
+    )
+    expect(config.field_types).to eq({
+        'count' => 'integer'
+    })
+  end
+
+  context "with float type" do
+    it "sets float mapping" do
+      allow(config).to receive(:file_config).and_return([{'name' => 'one.csv'}])
+      allow(config).to receive(:dictionary).and_return(
+        IndifferentHash.new percent:
+           {source:'PERCENT_COLUMN', type: 'float'}
+      )
+      expect(config.field_types).to eq({
+          'percent' => 'float'
+      })
+    end
+    it "can be excluded" do
+      allow(config).to receive(:dictionary).and_return(
+        IndifferentHash.new id: {source:'ID', type: 'integer'},
+          percent: {source:'PERCENT', type: 'float'}
+      )
+      allow(config).to receive(:file_config).and_return([
+        IndifferentHash.new({name:'one.csv',
+            only: ['id']})
+      ])
+      expect(config.field_types).to eq({
+          'id' => 'integer'
+      })
+
+    end
+    it "can be nested" do
+      allow(config).to receive(:dictionary).and_return(
+        IndifferentHash.new id: {source:'ID', type: 'integer'},
+          percent: {source:'PERCENT', type: 'float'}
+      )
+      allow(config).to receive(:file_config).and_return([
+        IndifferentHash.new({name:'one.csv',
+            only: ['id']}),
+        IndifferentHash.new({name:'two.csv',
+            nest: {key: '2012', contents: ['percent']}})
+      ])
+      expect(config.field_types).to eq({
+          'id' => 'integer',
+          '2012.percent' => 'float'
+      })
+
+    end
+
+
+  end
+
+  it "supports special case for location fields as nil" do
+    allow(config).to receive(:dictionary).and_return(
+      IndifferentHash.new 'location.lat': {source:'LAT_COLUMN'},
+                          'location.lon': {source:'LON_COLUMN'}
+
+    )
+    expect(config.field_types).to eq({
+      # special case for location in create_index
+    })
+  end
+
+
+
+end

--- a/spec/lib/data_magic/import_with_dictionary_spec.rb
+++ b/spec/lib/data_magic/import_with_dictionary_spec.rb
@@ -95,7 +95,7 @@ describe "DataMagic #import_with_dictionary" do
     after do
       DataMagic.destroy
     end
-    it "raises an error with invalid type" do
+    xit "raises an error with invalid type" do
       expect {
         DataMagic.init(load_now: true)
       }.to raise_error(Elasticsearch::Transport::Transport::Errors::BadRequest)

--- a/spec/lib/data_magic/import_with_dictionary_spec.rb
+++ b/spec/lib/data_magic/import_with_dictionary_spec.rb
@@ -87,6 +87,7 @@ describe "DataMagic #import_with_dictionary" do
       expect(result["total"]).to eq(50)
     end
   end
+
   context "with errors" do
     before do
       DataMagic.destroy
@@ -95,12 +96,14 @@ describe "DataMagic #import_with_dictionary" do
     after do
       DataMagic.destroy
     end
+
     xit "raises an error with invalid type" do
       expect {
         DataMagic.init(load_now: true)
       }.to raise_error(Elasticsearch::Transport::Transport::Errors::BadRequest)
     end
   end
+
   context "with options" do
     before(:all) do
       DataMagic.destroy
@@ -110,6 +113,7 @@ describe "DataMagic #import_with_dictionary" do
     after(:all) do
       DataMagic.destroy
     end
+
     it "'columns: all' indexed all columns and apply dictionary mapping to some" do
       result = DataMagic.search({GEOID: "3651000"}, api: 'cities')
       expected["results"] = [{"state"=>"NY", "GEOID"=>"3651000",
@@ -117,6 +121,7 @@ describe "DataMagic #import_with_dictionary" do
                               "population"=>"8175133", "year"=>2010}]
       expect(result).to eq(expected)
     end
+
     context "'limit_files: 1" do
       it "#config.files is of length 1" do
         expect(DataMagic.config.files.length).to eq(1)
@@ -126,6 +131,7 @@ describe "DataMagic #import_with_dictionary" do
         expect(result['total']).to eq(3)
       end
     end
+
     it "'rows: 2' indexes just 3 rows" do
       result = DataMagic.search({}, api: 'cities')
       expect(result['total']).to eq(3)

--- a/spec/lib/data_magic/import_with_nested_files_spec.rb
+++ b/spec/lib/data_magic/import_with_nested_files_spec.rb
@@ -33,10 +33,13 @@ describe "unique key(s)" do
     end
   end
 
-  context "can import a list" do
+  it "can search on a nested field" do
     DataMagic.config = DataMagic::Config.new
     DataMagic.import_with_dictionary
-    result = DataMagic.search({'stats.year'=> '2013'})
+    result = DataMagic.search({'2013.earnings.median' => 26318})
+    expect(result['total']).to eq(1)
+    first = result['results'].first
+    expect(first['2013']['earnings']).to eq({"percent_gt_25k"=>0.53, "median"=>26318})
   end
 
 end

--- a/spec/lib/data_magic/import_with_nested_files_spec.rb
+++ b/spec/lib/data_magic/import_with_nested_files_spec.rb
@@ -36,10 +36,10 @@ describe "unique key(s)" do
   it "can search on a nested field" do
     DataMagic.config = DataMagic::Config.new
     DataMagic.import_with_dictionary
-    result = DataMagic.search({'2013.earnings.median' => 26318})
+    result = DataMagic.search({'2013.earnings.6_yrs_after_entry.median' => 26318})
     expect(result['total']).to eq(1)
     first = result['results'].first
-    expect(first['2013']['earnings']).to eq({"percent_gt_25k"=>0.53, "median"=>26318})
+    expect(first['2013']['earnings']['6_yrs_after_entry']).to eq({"percent_gt_25k"=>0.53, "median"=>26318})
   end
 
 end


### PR DESCRIPTION
for example, the following queries now work:
http://localhost:3000/school?school.degrees_awarded.predominant=3&fields=id,school.name,school.degrees_awarded.predominant
http://localhost:3000/school?school.zip=99645&fields=school.zip,id,school.name
note: there is a pending test, right now error reporting for incorrect type from data.yaml is broken