### PR TITLE
[#95] Fix bug in sorting by field with multiple words

### DIFF
--- a/lib/data_magic.rb
+++ b/lib/data_magic.rb
@@ -120,10 +120,7 @@ module DataMagic
       logger.info "create_index field_types: #{field_types.inspect[0..500]}"
       es_index_name ||= self.config.scoped_index_name
       field_types['location'] = 'geo_point'
-      es_types = {}
-      field_types.each do |key, type|
-        es_types[key] = { type: type }
-      end
+      es_types = prepare_field_types(field_types)
       es_types = NestedHash.new.add(es_types)
       nested_object_type(es_types)
       begin
@@ -144,6 +141,14 @@ module DataMagic
         end
       end
       es_index_name
+    end
+
+    def self.prepare_field_types(field_types)
+      custom_indices = { 'name' => 'not_analyzed' }
+      field_types.each_with_object({}) do |(key, type), result|
+        result[key] = { type: type }
+        result[key][:index] = custom_indices[key] if custom_indices.has_key?(key)
+      end
     end
 
 

--- a/lib/data_magic/query_builder.rb
+++ b/lib/data_magic/query_builder.rb
@@ -20,7 +20,7 @@ module DataMagic
       def generate_squery(params, config)
         squery = Stretchy.query(type: 'document')
         squery = search_location(squery, params)
-        squery = search_fields_and_ranges(squery, params)
+        search_fields_and_ranges(squery, params)
       end
 
       def get_restrict_fields(options)

--- a/spec/lib/data_magic_spec.rb
+++ b/spec/lib/data_magic_spec.rb
@@ -10,4 +10,18 @@ describe DataMagic do
     #expect(DataMagic.client.indices.get(index: '_all')).to be_empty
   end
 
+  describe '.prepare_field_types' do
+    it 'returns the given fields with their specified type' do
+      expect(described_class.prepare_field_types({ 'state' => 'string', land_area: 'string' }))
+      .to eq("state" => { :type => "string" }, :land_area => { :type => "string" })
+    end
+
+    context 'when the key is "name"' do
+      it 'returns type with :index of "not_analyzed"' do
+        expect(described_class.prepare_field_types({ 'state' => 'string', 'name' => 'string' }))
+        .to eq({"state"=>{:type=>"string"}, "name"=>{:type=>"string", :index=>"not_analyzed"}})
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
This fixes the bug where sorting and searching by fields with multiple words (e.g. "New York") returns fuzzy matches. Hope the formatting changes in the spec are okay. Also DRY'd up the use of `result = JSON.parse(last_response.body)` in the feature spec.

NOTE: Searching by name will now only return exact case sensitive matches. May want to add another index to do fuzzy matching on name, if desired. 
