### PR TITLE
better error catching / raising

### DIFF
--- a/lib/data_magic/index.rb
+++ b/lib/data_magic/index.rb
@@ -128,11 +128,16 @@ module DataMagic
       end
 
     rescue Exception => e
-      Config.logger.error e.message
-      rows = []
+        if e.class == ArgumentError && e.message == "invalid byte sequence in UTF-8"
+          Config.logger.error e.message
+          raise InvalidData, "invalid file format" if num_rows == 0
+          rows = []
+        else
+          raise e
+        end
     end
 
-    raise InvalidData, "invalid file format or zero rows" if num_rows == 0
+    raise InvalidData, "zero rows" if num_rows == 0
     client.indices.refresh index: es_index_name
 
     return [num_rows, headers]


### PR DESCRIPTION
don’t want to mask other exception when there’s a UTF-8 error
now we *should* raise the correct (unexpected) exception