### PR TITLE
create custom type ‘literal’ for not_analyzed text

### DIFF
--- a/lib/data_magic.rb
+++ b/lib/data_magic.rb
@@ -120,7 +120,7 @@ module DataMagic
       logger.info "create_index field_types: #{field_types.inspect[0..500]}"
       es_index_name ||= self.config.scoped_index_name
       field_types['location'] = 'geo_point'
-      es_types = prepare_field_types(field_types)
+      es_types = es_field_types(field_types)
       es_types = NestedHash.new.add(es_types)
       nested_object_type(es_types)
       begin
@@ -143,11 +143,12 @@ module DataMagic
       es_index_name
     end
 
-    def self.prepare_field_types(field_types)
-      custom_indices = { 'name' => 'not_analyzed' }
+    # convert the types from data.yaml to Elasticsearch-specific types
+    def self.es_field_types(field_types)
+      custom_type = { 'literal' => {type: 'string', index:'not_analyzed'} }
       field_types.each_with_object({}) do |(key, type), result|
-        result[key] = { type: type }
-        result[key][:index] = custom_indices[key] if custom_indices.has_key?(key)
+        result[key] = custom_type[type]
+        result[key] ||= { type: type }
       end
     end
 

--- a/lib/data_magic.rb
+++ b/lib/data_magic.rb
@@ -120,10 +120,7 @@ module DataMagic
       logger.info "create_index field_types: #{field_types.inspect[0..500]}"
       es_index_name ||= self.config.scoped_index_name
       field_types['location'] = 'geo_point'
-      es_types = {}
-      field_types.each do |key, type|
-        es_types[key] = { type: type }
-      end
+      es_types = prepare_field_types(field_types)
       es_types = NestedHash.new.add(es_types)
       nested_object_type(es_types)
       begin
@@ -144,6 +141,14 @@ module DataMagic
         end
       end
       es_index_name
+    end
+
+    def self.prepare_field_types(field_types)
+      custom_indices = { 'name' => 'not_analyzed' }
+      field_types.each_with_object({}) do |(key, type), result|
+        result[key] = { type: type }
+        result[key][:index] = custom_indices[key] if custom_indices.has_key?(key)
+      end
     end
 
 

--- a/lib/data_magic/query_builder.rb
+++ b/lib/data_magic/query_builder.rb
@@ -20,7 +20,7 @@ module DataMagic
       def generate_squery(params, config)
         squery = Stretchy.query(type: 'document')
         squery = search_location(squery, params)
-        squery = search_fields_and_ranges(squery, params)
+        search_fields_and_ranges(squery, params)
       end
 
       def get_restrict_fields(options)

--- a/sample-data/data.yaml
+++ b/sample-data/data.yaml
@@ -10,7 +10,9 @@ api: cities
 unique: ['name']
 dictionary:
   state: USPS
-  name: NAME
+  name:
+    source: NAME
+    type: literal
   population:
     source: POP10
     type: integer

--- a/spec/features/api_spec.rb
+++ b/spec/features/api_spec.rb
@@ -9,7 +9,7 @@ shared_examples_for "api request" do
 
     it "allows GET HTTP method thru CORS" do
       allowed_http_methods = last_response.header['Access-Control-Allow-Methods']
-      %w{GET}.each do |method|  # don't expect we'll need: POST PUT DELETE
+      %w{GET}.each do |method| # don't expect we'll need: POST PUT DELETE
         expect(allowed_http_methods).to include(method)
       end
     end
@@ -18,6 +18,8 @@ end
 
 
 describe 'api', type: 'feature' do
+  let(:json_response) { JSON.parse(last_response.body) }
+
   context 'with sample data' do
     # app starts up in advance of before :all so for now testing only
     # with ./sample-data
@@ -32,28 +34,24 @@ describe 'api', type: 'feature' do
 
       expect(last_response).to be_ok
       expect(last_response.content_type).to eq('application/json')
-
-      result = JSON.parse(last_response.body)
       expected = {
-        'endpoints'=>[
-          'name'=>'cities',
-          'url'=>'/cities',
+        'endpoints' => [
+          'name' => 'cities',
+          'url' => '/cities',
         ]
       }
-      expect(result).to eq expected
+      expect(json_response).to eq expected
     end
 
     it "raises a 404 on missing endpoints" do
       get "/missing"
       expect(last_response.status).to eq(404)
       expect(last_response.content_type).to eq('application/json')
-
-      result = JSON.parse(last_response.body)
       expected = {
-        "error"=>404,
-        "message"=>"missing not found. Available endpoints: cities",
+        "error" => 404,
+        "message" => "missing not found. Available endpoints: cities",
       }
-      expect(result).to eq(expected)
+      expect(json_response).to eq(expected)
     end
 
     describe "data description" do
@@ -80,39 +78,31 @@ describe 'api', type: 'feature' do
         it "responds with json" do
           expect(last_response).to be_ok
           expect(last_response.content_type).to eq('application/json')
-
-          result = JSON.parse(last_response.body)
-
           expected = {
             "total" => 1,
-            "page"  => 0,
+            "page" => 0,
             "per_page" => DataMagic::DEFAULT_PAGE_SIZE,
             "results" => [
-              {"state"=>"IL", "name"=>"Chicago", "population"=>2695598,
-               "land_area"=>227.635,   # later we'll make this a float
-               "location"=>{"lat"=>41.837551, "lon"=>-87.681844}}            ]
+              { "state" => "IL", "name" => "Chicago", "population" => 2695598,
+                "land_area" => 227.635, # later we'll make this a float
+                "location" => { "lat" => 41.837551, "lon" => -87.681844 } }]
           }
-          expect(result).to eq(expected)
-
+          expect(json_response).to eq(expected)
         end
       end
+
       describe "with options" do
         it "can return a subset of fields" do
           get '/cities?state=MA&fields=name,population'
-
           expect(last_response).to be_ok
-          result = JSON.parse(last_response.body)
-
           expected = {
             "total" => 1,
-            "page"  => 0,
+            "page" => 0,
             "per_page" => DataMagic::DEFAULT_PAGE_SIZE,
-            "results" => [{"name"=>"Boston", "population"=>617594}]
+            "results" => [{ "name" => "Boston", "population" => 617594 }]
           }
-          expect(result).to eq(expected)
-
+          expect(json_response).to eq(expected)
         end
-
       end
 
       describe "with float" do
@@ -123,22 +113,18 @@ describe 'api', type: 'feature' do
         it "responds with json" do
           expect(last_response).to be_ok
           expect(last_response.content_type).to eq('application/json')
-
-          result = JSON.parse(last_response.body)
-
           expected = {
             "total" => 1,
-            "page"  => 0,
+            "page" => 0,
             "per_page" => DataMagic::DEFAULT_PAGE_SIZE,
-            "results" => [{"state"=>"NY", "name"=>"New York",
-              "population"=>8175133, "land_area"=>302.643,
-              "location"=>{"lat"=>40.664274, "lon"=>-73.9385}}]
-            }
-          expect(result).to eq(expected)
-
+            "results" => [{ "state" => "NY", "name" => "New York",
+                            "population" => 8175133, "land_area" => 302.643,
+                            "location" => { "lat" => 40.664274, "lon" => -73.9385 } }]
+          }
+          expect(json_response).to eq(expected)
         end
-
       end
+
       describe "near zipcode" do
         before do
           get '/cities?zip=94132&distance=30mi'
@@ -146,9 +132,7 @@ describe 'api', type: 'feature' do
 
         it "can find an attribute from an imported file" do
           expect(last_response).to be_ok
-          result = JSON.parse(last_response.body)
-          result["results"] = result["results"].sort_by { |k| k["name"] }
-
+          json_response["results"] = json_response["results"].sort_by { |k| k["name"] }
           expected = {
             "total" => 1,
             "page"  => 0,
@@ -156,16 +140,25 @@ describe 'api', type: 'feature' do
             "results" => [
               {"state"=>"CA", "name"=>"Oakland", "population"=>390724, "land_area"=>55.786, "location"=>{"lat"=>37.769857, "lon"=>-122.22564}}]
           }
-          expect(result).to eq(expected)
+          expect(json_response).to eq(expected)
         end
       end
 
+      # @todo add example with multi words
       describe "with sort" do
-        it "can sort numbers ascending" do
+        it 'returns the data sorted by population in ascending order' do
           get '/cities?sort=population:asc'
           expect(last_response).to be_ok
-          response = JSON.parse(last_response.body)
-          expect(response["results"][0]['name']).to eq("Rochester")
+          expect(json_response["results"][0]['name']).to eq("Rochester")
+        end
+
+        context 'when :sort is "name"' do
+          it 'returns the data sorted by name in descending order' do
+            get '/cities?sort=name:desc&per_page=100'
+            expect(last_response).to be_ok
+            expect(json_response["results"][0]['name']).to eq("Winston-Salem")
+            expect(json_response["results"][-1]['name']).to eq("Albuquerque")
+          end
         end
       end
     end
@@ -185,56 +178,52 @@ describe 'api', type: 'feature' do
     let(:expected) {
       {
         "total" => 1,
-        "page"  => 0,
+        "page" => 0,
         "per_page" => DataMagic::DEFAULT_PAGE_SIZE,
-        "results" => [{"id"=>"9", "city"=>"Tanner", "state"=>"AL",
-          "name"=>"Inquisitive Farm College",
-          "2013"=>{"earnings"=>
-                    {"6_yrs_after_entry"=>
-                        {"percent_gt_25k"=>0.19, "median"=>34183}},
-                   "sat_average"=>"971"},
-          "2012"=>{"earnings"=>
-                    {"6_yrs_after_entry"=>
-                        {"percent_gt_25k"=>0.83, "median"=>42150}},
-          "sat_average"=>"1292"}}]
-        }
+        "results" => [{ "id" => "9", "city" => "Tanner", "state" => "AL",
+                        "name" => "Inquisitive Farm College",
+                        "2013" => { "earnings" =>
+                                      { "6_yrs_after_entry" =>
+                                          { "percent_gt_25k" => 0.19, "median" => 34183 } },
+                                    "sat_average" => "971" },
+                        "2012" => { "earnings" =>
+                                      { "6_yrs_after_entry" =>
+                                          { "percent_gt_25k" => 0.83, "median" => 42150 } },
+                                    "sat_average" => "1292" } }]
+      }
     }
     it "can search" do
-      get '/school?name=Inquisitive Farm'
+      get '/school?name=Inquisitive Farm College'
       expect(last_response).to be_ok
-      result = JSON.parse(last_response.body)
-      expect(result).to eq(expected)
+      expect(json_response).to eq(expected)
     end
     it "can search for nested number" do
       get '/school?2013.earnings.6_yrs_after_entry.median=34183'
       expect(last_response).to be_ok
-      result = JSON.parse(last_response.body)
-      expect(result).to eq(expected)
+      expect(json_response).to eq(expected)
     end
 
     it "can search for nested float" do
       get '/school?2013.earnings.6_yrs_after_entry.percent_gt_25k=0.19'
       expect(last_response).to be_ok
-      result = JSON.parse(last_response.body)
-      expect(result).to eq(expected)
+      expect(json_response).to eq(expected)
     end
 
     it "can search for range" do
       get '/school?2013.earnings.6_yrs_after_entry.median__range=49310..'
       expect(last_response).to be_ok
-      result = JSON.parse(last_response.body)
       expected["results"] = [
-        {"id"=>"8", "city"=>"Birmingham", "state"=>"AL",
-            "name"=>"Condemned Balloon Institute",
-            "2013"=>{"earnings"=>
-                      {"6_yrs_after_entry"=>
-                        {"percent_gt_25k"=>0.59, "median"=>59759}},
-                     "sat_average"=>"616"},
-            "2012"=>{"earnings"=>
-                      {"6_yrs_after_entry"=>
-                          {"percent_gt_25k"=>0.97, "median"=>30063}},
-                     "sat_average"=>"1420"}}]
-      expect(result).to eq(expected)
+        { "id" => "8", "city" => "Birmingham", "state" => "AL",
+          "name" => "Condemned Balloon Institute",
+          "2013" => { "earnings" =>
+                        { "6_yrs_after_entry" =>
+                            { "percent_gt_25k" => 0.59, "median" => 59759 } },
+                      "sat_average" => "616" },
+          "2012" => { "earnings" =>
+                        { "6_yrs_after_entry" =>
+                            { "percent_gt_25k" => 0.97, "median" => 30063 } },
+                      "sat_average" => "1420" } }]
+      expect(json_response).to eq(expected)
     end
   end
 
@@ -245,41 +234,43 @@ describe 'api', type: 'feature' do
       DataMagic.config = DataMagic::Config.new
       DataMagic.import_with_dictionary
     end
+
     after do
       DataMagic.destroy
     end
+
     let(:expected) {
       {
         "total" => 1,
-        "page"  => 0,
+        "page" => 0,
         "per_page" => DataMagic::DEFAULT_PAGE_SIZE,
-        "results" => [{"id"=>9, "school"=>{"city"=>"Tanner", "state"=>"AL", "zip"=>35671, "name"=>"Inquisitive Farm College"}}]
-        }
+        "results" => [{ "id" => 9, "school" => { "city" => "Tanner", "state" => "AL", "zip" => 35671, "name" => "Inquisitive Farm College" } }]
+      }
     }
+
     it "can search for nested name" do
       get '/fakeschool?school.name=Inquisitive Farm'
       expect(last_response).to be_ok
-      result = JSON.parse(last_response.body)
-      expect(result).to eq(expected)
+      expect(json_response).to eq(expected)
     end
+
     it "can search for nested number" do
       get '/fakeschool?school.zip=35671'
       expect(last_response).to be_ok
-      result = JSON.parse(last_response.body)
-      expect(result).to eq(expected)
+      expect(json_response).to eq(expected)
     end
+
     it "can search for range" do
       get '/fakeschool?school.zip__range=36800..'
       expect(last_response).to be_ok
-      result = JSON.parse(last_response.body)
       expected["results"] = [
-        {"id"=>7,
-         "school"=>{"city"=>"Auburn University",
-              "state"=>"AL", "zip"=>36849,
-             "name"=>"Alabama Beauty College of Auburn University"}
-         }
+        { "id" => 7,
+          "school" => { "city" => "Auburn University",
+                        "state" => "AL", "zip" => 36849,
+                        "name" => "Alabama Beauty College of Auburn University" }
+        }
       ]
-      expect(result).to eq(expected)
+      expect(json_response).to eq(expected)
     end
   end
 end

--- a/spec/features/api_spec.rb
+++ b/spec/features/api_spec.rb
@@ -249,7 +249,7 @@ describe 'api', type: 'feature' do
     }
 
     it "can search for nested name" do
-      get '/fakeschool?school.name=Inquisitive Farm'
+      get '/fakeschool?school.name=Inquisitive Farm College'
       expect(last_response).to be_ok
       expect(json_response).to eq(expected)
     end

--- a/spec/fixtures/nested2/data.yaml
+++ b/spec/fixtures/nested2/data.yaml
@@ -24,6 +24,7 @@ dictionary:
     description: 6-digit OPE ID for institution
   school.name:
     source: INSTNM
+    type: literal
     description: Institution name
   school.city:
     source: CITY_MAIN

--- a/spec/fixtures/nested_files/data.yaml
+++ b/spec/fixtures/nested_files/data.yaml
@@ -5,7 +5,9 @@ unique: [id]
 
 dictionary:
   id: UNITID
-  name: INSTNM
+  name:
+    source: INSTNM
+    type: literal
   city: CITY_MAIN
   state: STABBR_MAIN
   zip: ZIP_MAIN

--- a/spec/lib/data_magic/config_spec.rb
+++ b/spec/lib/data_magic/config_spec.rb
@@ -80,7 +80,7 @@ describe DataMagic::Config do
     it "has config data" do
       default_config = {"version"=>"cities100-2010",
         "index"=>"city-data", "api"=>"cities",
-        "dictionary"=> {"state"=>"USPS", "name"=>"NAME",
+        "dictionary"=> {"state"=>"USPS", "name"=>{"source"=>"NAME", "type"=>"literal"},
                         "population"=>{"source"=>"POP10", "type"=>"integer"},
                         "location.lat"=>"INTPTLAT", "location.lon"=>"INTPTLONG",
                         "land_area"=>{"source"=>"ALAND_SQMI", "type"=>"float"}

--- a/spec/lib/data_magic_spec.rb
+++ b/spec/lib/data_magic_spec.rb
@@ -10,18 +10,20 @@ describe DataMagic do
     #expect(DataMagic.client.indices.get(index: '_all')).to be_empty
   end
 
-  describe '.prepare_field_types' do
+  describe '.es_field_types' do
     it 'returns the given fields with their specified type' do
-      expect(described_class.prepare_field_types({ 'state' => 'string', land_area: 'string' }))
-      .to eq("state" => { :type => "string" }, :land_area => { :type => "string" })
+      expect(described_class.es_field_types({ 'state' => 'string', land_area: 'string' }))
+      .to eq("state" => { :type => "string" },
+          :land_area => { :type => "string" })
     end
 
-    context 'when the key is "name"' do
-      it 'returns type with :index of "not_analyzed"' do
-        expect(described_class.prepare_field_types({ 'state' => 'string', 'name' => 'string' }))
+    context 'with custom type "literal"' do
+      it 'returns string type with :index of "not_analyzed"' do
+        expect(described_class.es_field_types({ 'state' => 'string', 'name' => 'literal' }))
         .to eq({"state"=>{:type=>"string"}, "name"=>{:type=>"string", :index=>"not_analyzed"}})
       end
     end
+
   end
 
 end

--- a/spec/lib/data_magic_spec.rb
+++ b/spec/lib/data_magic_spec.rb
@@ -10,4 +10,18 @@ describe DataMagic do
     #expect(DataMagic.client.indices.get(index: '_all')).to be_empty
   end
 
+  describe '.prepare_field_types' do
+    it 'returns the given fields with their specified type' do
+      expect(described_class.prepare_field_types({ 'state' => 'string', land_area: 'string' }))
+      .to eq("state" => { :type => "string" }, :land_area => { :type => "string" })
+    end
+
+    context 'when the key is "name"' do
+      it 'returns type with :index of "not_analyzed"' do
+        expect(described_class.prepare_field_types({ 'state' => 'string', 'name' => 'string' }))
+        .to eq({"state"=>{:type=>"string"}, "name"=>{:type=>"string", :index=>"not_analyzed"}})
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
integrates change by @ridiculus that allows us to have a name that will support an exact match
data.yaml now can have a 'literal' type for this behavior

```
dictionary:
  name:
    source: NAME
    type: literal
```