### PR TITLE
new ‘name’ type allows more intuitive searching for names

### DIFF
--- a/lib/data_magic.rb
+++ b/lib/data_magic.rb
@@ -149,7 +149,10 @@ module DataMagic
 
     # convert the types from data.yaml to Elasticsearch-specific types
     def self.es_field_types(field_types)
-      custom_type = { 'literal' => {type: 'string', index:'not_analyzed'} }
+      custom_type = {
+        'literal' => {type: 'string', index:'not_analyzed'},
+        'name' => {type: 'string', index:'not_analyzed'},
+     }
       field_types.each_with_object({}) do |(key, type), result|
         result[key] = custom_type[type]
         result[key] ||= { type: type }

--- a/lib/data_magic/config.rb
+++ b/lib/data_magic/config.rb
@@ -227,6 +227,10 @@ module DataMagic
       result
     end
 
+    def field_type(field_name)
+      field_types[field_name]
+    end
+
     # this is a mapping of the fields that end up in the json doc
     # to their types, which might include nested documents
     # but at this stage, field names use dot syntax for nesting

--- a/lib/data_magic/config.rb
+++ b/lib/data_magic/config.rb
@@ -105,20 +105,18 @@ module DataMagic
 
     # pull out all the fields that are specified in
     # only: [one, two, three]
-    # this means we should only take these fields from that file
+    # this means we should only take these fields from that file, or fields
+    # with the specified prefix
     def only_field_list(only_names, all_fields)
       logger.info "only_field_list #{only_names.inspect}"
       selected = {}
       only_names.each do |name|
-        # select the exact match or all the fields with prefix "whatever."
+        # pick all fields with given only_name as either exact match or prefix
         named = all_fields.select do |k,v|
-          logger.info "#{name.inspect} #{k.inspect}: #{k =~ /#{name}.*/}"
           name == k || ((k =~ /#{name}.*/) == 0)
         end
-        logger.info "#{name}: #{named.inspect}"
         selected.merge! named
       end
-      logger.info "selected #{selected.inspect}"
       selected
     end
 

--- a/lib/data_magic/index.rb
+++ b/lib/data_magic/index.rb
@@ -217,7 +217,7 @@ private
   end
 
   def self.valid_types
-    %w[integer float string literal]
+    %w[integer float string literal name]
   end
 
   def self.valid_type_config

--- a/lib/data_magic/query_builder.rb
+++ b/lib/data_magic/query_builder.rb
@@ -24,7 +24,7 @@ module DataMagic
       end
 
       def get_restrict_fields(options)
-        options[:fields].map { |field| field.to_s }
+        options[:fields].map(&:to_s)
       end
 
       # @description turns a string like "state,population:desc" into [{'state' => {order: 'asc'}},{ "population" => {order: "desc"} }]
@@ -46,20 +46,16 @@ module DataMagic
           if config.field_type(field) == "name"
             value = value.split(' ').map { |word| "#{word}*"}.join(' ')
             squery = squery.match.query(
-              "wildcard": {
-                 "name": {
-                    "value": value
-                 }
-                }
+              "wildcard": { "name": { "value": value } }
             )
           elsif match = /(.+)__(range|ne|not)\z/.match(field)
             var_name, operator = match.captures.map(&:to_sym)
             if operator == :ne or operator == :not  # field negation
               squery = squery.where.not(var_name => value)
             else  # field range
-              squery = squery.filter({
+              squery = squery.filter(
                 or: build_ranges(var_name, value.split(','))
-              })
+              )
             end
           else # field equality
             squery = squery.where(field => value)
@@ -72,12 +68,10 @@ module DataMagic
         range_strings.map do |range|
           min, max = range.split('..')
           values = {}
-          values[:gte] = to_number(min) if !min.empty?
+          values[:gte] = to_number(min) unless min.empty?
           values[:lte] = to_number(max) if max
           {
-            range: {
-              var_name => values
-            }
+            range: { var_name => values }
           }
         end
       end

--- a/spec/fixtures/types/data.yaml
+++ b/spec/fixtures/types/data.yaml
@@ -1,0 +1,23 @@
+
+version: 0
+# cities100.txt
+# National Places Gazetteer Files, from US Census 2010
+# https://www.census.gov/geo/maps-data/data/gazetteer2010.html
+# (head -n 1 source.txt && tail -n +2 source.txt | LC_ALL=C sort -k7rn,7 -t$'\t' source.txt) > result.txt
+# head -n 101 results.txt > cities100.txt
+# then convertes to csv and removed " city" from after each city name
+dictionary:
+  id:
+    source: id
+    type: literal
+  city.name:
+    source: name
+    type: name
+  city.state: state
+  location.lat: lat
+  location.lon: lon
+
+index: place-data
+api: places
+files:
+  - name: places.csv

--- a/spec/fixtures/types/places.csv
+++ b/spec/fixtures/types/places.csv
@@ -1,0 +1,4 @@
+id,state,name,lat,lon
+ca sf,CA,San Francisco,37.727239,-123.032229
+ny ny,NY,New York,40.664274,-73.938500
+la no,LA,New Orleans,30.068636,-89.939007

--- a/spec/lib/data_magic/config_spec.rb
+++ b/spec/lib/data_magic/config_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe DataMagic::Config do
-
   before(:all) do
     ENV['DATA_PATH'] = './spec/fixtures/import_with_dictionary'
   end
@@ -28,24 +27,23 @@ describe DataMagic::Config do
 
   context "s3" do
     it "detects data.yaml" do
-
-      DataMagic::Config.logger.info "="*40
-      DataMagic::Config.logger.info "="*40
       ENV['DATA_PATH'] = 's3://mybucket'
       fake_s3 = class_spy("Fake Aws::S3::Client")
-      fake_get_object_response = double("S3 response",
-        body: StringIO.new(
-          {'index'=> 'fake-index'}.to_yaml
-        ))
-      fake_list_objects_response = double("S3 response",
-          contents: [double("item", key:"data.yaml")])
+      fake_get_object_response = double(
+        "S3 response",
+        body: StringIO.new({ 'index' => 'fake-index' }.to_yaml)
+      )
+      fake_list_objects_response = double(
+        "S3 response",
+        contents: [double("item", key: "data.yaml")]
+      )
 
       allow(fake_s3).to receive(:get_object)
         .with(bucket: 'mybucket', key: 'data.yaml')
         .and_return(fake_get_object_response)
       allow(fake_s3).to receive(:list_objects)
-                    .with(bucket: 'mybucket')
-                    .and_return(fake_list_objects_response)
+        .with(bucket: 'mybucket')
+        .and_return(fake_list_objects_response)
       config = DataMagic::Config.new(s3: fake_s3)
       expect(config.s3).to eq(fake_s3)
       expect(config.data["index"]).to eq("fake-index")
@@ -65,11 +63,10 @@ describe DataMagic::Config do
   end
 
   context "when loaded" do
-    let(:config) {DataMagic::Config.new}
+    let(:config) { DataMagic::Config.new }
 
     after do
       config.clear_all
-      #expect(DataMagic.client.indices.get(index: '_all')).to be_empty
     end
 
     context "#scoped_index_name" do
@@ -79,20 +76,21 @@ describe DataMagic::Config do
     end
 
     it "has config data" do
-      default_config = {"version"=>"cities100-2010",
-        "index"=>"city-data", "api"=>"cities",
-        "files" => [{"name"=>"cities100.csv"}],
+      default_config = {
+        "version" => "cities100-2010",
+        "index" => "city-data", "api" => "cities",
+        "files" => [{ "name" => "cities100.csv" }],
         "data_path" => "./sample-data",
-        "options"=>{},
-        "unique"=>["name"],
+        "options" => {},
+        "unique" => ["name"]
       }
       expect(config.data.keys).to include('dictionary')
       dictionary = config.data.delete 'dictionary'
 
-      expect(dictionary.keys.sort).to eq %w[id code name state population
-        location.lat location.lon area.land area.water].sort
+      expect(dictionary.keys.sort).to eq %w(id code name state population
+        location.lat location.lon area.land area.water).sort
       categories = config.data.delete 'categories'
-      expect(categories.keys.sort).to eq %w[general geographic].sort
+      expect(categories.keys.sort).to eq %w(general geographic).sort
       expect(config.data).to eq(default_config)
     end
 
@@ -103,13 +101,12 @@ describe DataMagic::Config do
 
     it "has can parse expressions" do
       expr = "ONE or TWO"
-      expect(config.parse_expression(expr)).to eq(['ONE', 'TWO'])
+      expect(config.parse_expression(expr)).to eq(%w(ONE TWO))
     end
 
-
-    describe "#update_indexed_config" do   #rename ... or do this in load_config or something
+    describe "#update_indexed_config" do # rename ... or do this in load_config or something
       context "after loading config" do
-        let(:fixture_path) {"./spec/fixtures/import_with_dictionary"}
+        let(:fixture_path) { "./spec/fixtures/import_with_dictionary" }
         before do
           config.load_datayaml(fixture_path)
         end
@@ -124,7 +121,6 @@ describe DataMagic::Config do
           config.update_indexed_config
           expect(config.update_indexed_config).to be false
         end
-
       end
     end
 
@@ -141,26 +137,24 @@ describe DataMagic::Config do
   end
 
   context "helper method" do
-    let(:config) {DataMagic::Config.new(load_datayaml:false)}
-    let(:simple_fields) {
-      {'one'=> 'column1', 'two' => 'column2', 'three' => 'column3'}
-    }
-    let(:fields_with_dots) {
-      {'one'=> 'column1', 'two.a' => 'column2a', 'two.b' => 'column2b'}
-    }
+    let(:config) { DataMagic::Config.new(load_datayaml: false) }
+    let(:simple_fields) do
+      { 'one' => 'column1', 'two' => 'column2', 'three' => 'column3' }
+    end
+    let(:fields_with_dots) do
+      { 'one' => 'column1', 'two.a' => 'column2a', 'two.b' => 'column2b' }
+    end
 
     it ".only_field_list selects a subset" do
-
-      expect(config.only_field_list(%w[one two], simple_fields)).to eq(
-        {'one'=> 'column1', 'two' => 'column2'}
-      )
-    end
-    it ".only_field_list selects a fields with dots" do
-
-      expect(config.only_field_list(%w[two], fields_with_dots)).to eq(
-        {'two.a' => 'column2a', 'two.b' => 'column2b'}
+      expect(config.only_field_list(%w(one two), simple_fields)).to eq(
+        'one' => 'column1', 'two' => 'column2'
       )
     end
 
+    it ".only_field_list selects fields with dots" do
+      expect(config.only_field_list(%w(two), fields_with_dots)).to eq(
+        'two.a' => 'column2a', 'two.b' => 'column2b'
+      )
+    end
   end
 end

--- a/spec/lib/data_magic/config_spec.rb
+++ b/spec/lib/data_magic/config_spec.rb
@@ -139,4 +139,28 @@ describe DataMagic::Config do
       end
     end
   end
+
+  context "helper method" do
+    let(:config) {DataMagic::Config.new(load_datayaml:false)}
+    let(:simple_fields) {
+      {'one'=> 'column1', 'two' => 'column2', 'three' => 'column3'}
+    }
+    let(:fields_with_dots) {
+      {'one'=> 'column1', 'two.a' => 'column2a', 'two.b' => 'column2b'}
+    }
+
+    it ".only_field_list selects a subset" do
+
+      expect(config.only_field_list(%w[one two], simple_fields)).to eq(
+        {'one'=> 'column1', 'two' => 'column2'}
+      )
+    end
+    it ".only_field_list selects a fields with dots" do
+
+      expect(config.only_field_list(%w[two], fields_with_dots)).to eq(
+        {'two.a' => 'column2a', 'two.b' => 'column2b'}
+      )
+    end
+
+  end
 end

--- a/spec/lib/data_magic/import_without_data_yaml_spec.rb
+++ b/spec/lib/data_magic/import_without_data_yaml_spec.rb
@@ -14,7 +14,6 @@ describe "DataMagic #import_without_data_yaml" do
   end
 
   before(:all) do
-    DataMagic::Config.logger.info "===== before :all"
     DataMagic.destroy
     ENV['DATA_PATH'] = './spec/fixtures/cities_without_yml'
     DataMagic.init(load_now: true)

--- a/spec/lib/data_magic/name_type_spec.rb
+++ b/spec/lib/data_magic/name_type_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+require 'data_magic'
+
+describe "DataMagic name types" do
+
+  before :example do
+    DataMagic.destroy
+    ENV['DATA_PATH'] = './spec/fixtures/types'
+    DataMagic.init(load_now: true)
+  end
+  after :example do
+    DataMagic.destroy
+  end
+
+  it "can search for one word" do
+    response = DataMagic.search({'city.name' => 'New'}, fields:['city.name'])
+    results = response['results'].sort {|a,b| a['city.name'] <=> b['city.name']}
+    expect(results).to eq(
+      [{"city.name"=>"New Orleans"}, {"city.name"=>"New York"}])
+  end
+
+  it "can search for multiple words" do
+    response = DataMagic.search({'city.name' => 'New York'}, fields:['city.name'])
+    results = response['results']
+    expect(results).to eq(
+      [{"city.name"=>"New York"}])
+  end
+
+  it "can search for partial words" do
+    response = DataMagic.search({'city.name' => 'S Fran'}, fields:['city.name'])
+    results = response['results']
+    expect(results).to eq(
+      [{"city.name"=>"San Francisco"}])
+  end
+
+  xit "is not case sensitive" do
+    response = DataMagic.search({'city.name' => 'new'}, fields:['city.name'])
+    results = response['results'].sort {|a,b| a['city.name'] <=> b['city.name']}
+    expect(results).to eq(
+      [{"city.name"=>"New Orleans"}, {"city.name"=>"New York"}])
+  end
+end


### PR DESCRIPTION
technically we index as ‘not analyzed’
then query with wildcard match at end of each word
Searching for "New" should find "New York" and "New Orleans"
Searching for "New York" should find "New York" 
Searching for "Boston Univ" should find "Boston University" 