### PR TITLE
API error handling, part 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,30 @@ export DATA_PATH='./data'
         1. If data.yaml not provided, all fields and fields will be imported with folder or bucket name used as the API endpoint (name is 'slugified' with dashes replacing spaces)
 1. api endpoint to get the data /api=endpoint?field_or_column_name=value
 
+## More Configuration Options
+
+Often while you are developing an API and data dictionary,
+it is helpful to include all the columns in the csv.  If you add the following to
+data.yaml, the field names and types from the dictionary will be used and any
+unspecified columns will simply use the column name as the field name.
+
+```
+options:
+  columns: all
+```
+
+You can use the dictionary to provide nice errors to developers who use the API.
+This can be used in conjunction with the above ```columns: all``` which will
+make it so that columns that are not referenced in the dictionary are not
+searchable, but will make it so that unspecified fields cause errors to be
+reported.
+
+```
+options:
+  search: dictionary_only
+```
+
+
 ## Help Wanted
 
 1. Try out importing multiple data sets with different endpoints and data.yaml configuration

--- a/app/controllers.rb
+++ b/app/controllers.rb
@@ -46,6 +46,7 @@ OpenDataMaker::App.controllers :v1 do
     end
 
     data = DataMagic.search(params, sort: sort, api: endpoint, fields: fields)
+    halt 400, data.to_json if data.key?(:errors)
 
     if format == 'csv'
       output_data_as_csv(data['results'])

--- a/app/controllers.rb
+++ b/app/controllers.rb
@@ -34,7 +34,7 @@ OpenDataMaker::App.controllers :v1 do
   end
 
   get :index, with: :endpoint, provides: [:json, :csv] do
-    (endpoint, sort, fields, format) = get_search_args_from_params(params)
+    (endpoint, options, format) = get_search_args_from_params(params)
     content_type format.to_sym if format
     DataMagic.logger.debug "-----> APP GET #{params.inspect}"
 
@@ -45,7 +45,7 @@ OpenDataMaker::App.controllers :v1 do
       }.to_json
     end
 
-    data = DataMagic.search(params, sort: sort, api: endpoint, fields: fields)
+    data = DataMagic.search(params, options)
     halt 400, data.to_json if data.key?(:errors)
 
     if format == 'csv'
@@ -58,10 +58,17 @@ end
 
 def get_search_args_from_params(params)
   endpoint = params.delete("endpoint")
-  sort = params.delete("sort")
-  fields = (params.delete('fields') || "").split(',')
+  options = {
+    api: endpoint,
+    sort: params.delete("sort"),
+    zip: params.delete("zip"),
+    distance: params.delete("distance"),
+    fields: (params.delete('fields') || "").split(','),
+    per_page: params.delete("per_page") || DataMagic.config.page_size,
+    page: params.delete("page").to_i || 0
+  }
   format = params.delete('format')
-  [endpoint, sort, fields, format]
+  [endpoint, options, format]
 end
 
 def output_data_as_csv(results)

--- a/lib/data_magic.rb
+++ b/lib/data_magic.rb
@@ -23,7 +23,6 @@ class IndifferentHash < Hash
 end
 
 module DataMagic
-
   class << self
     attr_accessor :config
     def logger
@@ -112,137 +111,137 @@ module DataMagic
   end
 
   private
-    def self.nested_object_type(hash)
-      hash.each do |key, value|
-       if value.is_a?(Hash) && value[:type].nil?  # things are nested under this
-          hash[key] = {
-            path: "full", type: "object",
-            properties: value
-          }
-          nested_object_type(value)
-        end
+
+  def self.nested_object_type(hash)
+    hash.each do |key, value|
+      if value.is_a?(Hash) && value[:type].nil?  # things are nested under this
+        hash[key] = {
+          path: "full", type: "object",
+          properties: value
+        }
+        nested_object_type(value)
       end
     end
+  end
 
-    def self.create_index(es_index_name = nil, field_types={})
-      logger.info "create_index field_types: #{field_types.inspect[0..500]}"
-      es_index_name ||= self.config.scoped_index_name
-      field_types['location'] = 'geo_point'
-      es_types = es_field_types(field_types)
-      es_types = NestedHash.new.add(es_types)
-      nested_object_type(es_types)
-      begin
-        logger.info "====> creating index with type mapping: #{es_types.inspect[0..500]}"
-        client.indices.create index: es_index_name, body: {
-          mappings: {
-            document: {    # type 'document' is always used for external indexed docs
-              properties: es_types
-            }
+  def self.create_index(es_index_name = nil, field_types={})
+    logger.info "create_index field_types: #{field_types.inspect[0..500]}"
+    es_index_name ||= self.config.scoped_index_name
+    field_types['location'] = 'geo_point'
+    es_types = es_field_types(field_types)
+    es_types = NestedHash.new.add(es_types)
+    nested_object_type(es_types)
+    begin
+      logger.info "====> creating index with type mapping: #{es_types.inspect[0..500]}"
+      client.indices.create index: es_index_name, body: {
+        mappings: {
+          document: {    # type 'document' is always used for external indexed docs
+            properties: es_types
           }
         }
-      rescue Elasticsearch::Transport::Transport::Errors::BadRequest => error
-        if error.message.include? "IndexAlreadyExistsException"
-          logger.debug "create_index failed: #{es_index_name} already exists"
-        else
-          logger.error error.to_s
-          raise error
+      }
+    rescue Elasticsearch::Transport::Transport::Errors::BadRequest => error
+      if error.message.include? "IndexAlreadyExistsException"
+        logger.debug "create_index failed: #{es_index_name} already exists"
+      else
+        logger.error error.to_s
+        raise error
+      end
+    end
+    es_index_name
+  end
+
+  # convert the types from data.yaml to Elasticsearch-specific types
+  def self.es_field_types(field_types)
+    custom_type = { 'literal' => {type: 'string', index:'not_analyzed'} }
+    field_types.each_with_object({}) do |(key, type), result|
+      result[key] = custom_type[type]
+      result[key] ||= { type: type }
+    end
+  end
+
+
+  # get the real index name when given either
+  # api: api endpoint configured in data.yaml
+  # index: index name
+  def self.index_name_from_options(options)
+    options[:api] = options['api'].to_sym if options['api']
+    options[:index] = options['index'].to_sym if options['index']
+    logger.info "WARNING: DataMagic.search options api will override index, only one expected"  if options[:api] and options[:index]
+    if options[:api]
+      index_name = config.find_index_for(options[:api])
+      if index_name.nil?
+        raise ArgumentError, "no configuration found for '#{options[:api]}', available endpoints: #{self.config.api_endpoint_names.inspect}"
+      end
+    else
+      index_name = options[:index]
+    end
+    index_name = self.config.scoped_index_name(index_name)
+  end
+
+  def self.index_data_if_needed
+    logger.info "index_data_if_needed"
+    if @index_thread and @index_thread.alive?
+      logger.info "already indexing... skip!"
+    else
+      if config.update_indexed_config
+        logger.info "new config detected... hitting the big RESET button"
+        @index_thread = Thread.new do
+          logger.info "re-indexing..."
+
+          self.import_with_dictionary
+          logger.info "indexing on a thread"
         end
       end
-      es_index_name
     end
+  end
 
-    # convert the types from data.yaml to Elasticsearch-specific types
-    def self.es_field_types(field_types)
-      custom_type = { 'literal' => {type: 'string', index:'not_analyzed'} }
-      field_types.each_with_object({}) do |(key, type), result|
-        result[key] = custom_type[type]
-        result[key] ||= { type: type }
-      end
-    end
-
-
-    # get the real index name when given either
-    # api: api endpoint configured in data.yaml
-    # index: index name
-    def self.index_name_from_options(options)
-      options[:api] = options['api'].to_sym if options['api']
-      options[:index] = options['index'].to_sym if options['index']
-      logger.info "WARNING: DataMagic.search options api will override index, only one expected"  if options[:api] and options[:index]
-      if options[:api]
-        index_name = config.find_index_for(options[:api])
-        if index_name.nil?
-          raise ArgumentError, "no configuration found for '#{options[:api]}', available endpoints: #{self.config.api_endpoint_names.inspect}"
+  def self.client
+    if @client.nil?
+      if ENV['VCAP_APPLICATION']    # Cloud Foundry
+        logger.info "connect to Cloud Foundry elasticsearch service"
+        eservice = ::CF::App::Credentials.find_by_service_name('eservice')
+        logger.info "eservice: #{eservice.inspect}"
+        service_uri = eservice['url'] || eservice['uri']
+        logger.info "service_uri: #{service_uri}"
+        @client = ::Elasticsearch::Client.new host: service_uri  #, log: true
+        Stretchy.configure do |c|
+          c.client     = @client                       # use a custom client
         end
       else
-        index_name = options[:index]
-      end
-      index_name = self.config.scoped_index_name(index_name)
-    end
-
-    def self.index_data_if_needed
-      logger.info "index_data_if_needed"
-      if @index_thread and @index_thread.alive?
-        logger.info "already indexing... skip!"
-      else
-        if config.update_indexed_config
-          logger.info "new config detected... hitting the big RESET button"
-          @index_thread = Thread.new do
-            logger.info "re-indexing..."
-
-            self.import_with_dictionary
-            logger.info "indexing on a thread"
-          end
-        end
+        logger.info "default local elasticsearch connection"
+        @client = ::Elasticsearch::Client.new #log: true
       end
     end
+    @client
+  end
 
-    def DataMagic.client
-      if @client.nil?
-        if ENV['VCAP_APPLICATION']    # Cloud Foundry
-          logger.info "connect to Cloud Foundry elasticsearch service"
-          eservice = ::CF::App::Credentials.find_by_service_name('eservice')
-          logger.info "eservice: #{eservice.inspect}"
-          service_uri = eservice['url'] || eservice['uri']
-          logger.info "service_uri: #{service_uri}"
-          @client = ::Elasticsearch::Client.new host: service_uri  #, log: true
-          Stretchy.configure do |c|
-            c.client     = @client                       # use a custom client
-          end
-        else
-          logger.info "default local elasticsearch connection"
-          @client = ::Elasticsearch::Client.new #log: true
-        end
-      end
-      @client
+  # call this before calling anything that requires data.yaml
+  # this will load data.yaml, and optionally index referenced data
+  # options hash
+  #   load_now: default load in background,
+  #             false don't load,
+  #             true load immediately, wait for complete indexing
+  def self.init(options = {})
+    logger.info "--"*20
+    logger.info "    DataMagic init VCAP_APPLICATION=#{ENV['VCAP_APPLICATION'].inspect}"
+    logger.info "--"*20
+    logger.info "options: #{options.inspect}"
+    logger.info "self.config: #{self.config.inspect}"
+    if self.config.nil?   # only init once
+      ::Aws.eager_autoload!       # see https://github.com/aws/aws-sdk-ruby/issues/833
+      self.config = Config.new(s3: self.s3)    # loads data.yaml
+      self.index_data_if_needed unless options[:load_now] == false
+      @index_thread.join if options[:load_now] and @index_thread
     end
+  end # init
 
-    # call this before calling anything that requires data.yaml
-    # this will load data.yaml, and optionally index referenced data
-    # options hash
-    #   load_now: default load in background,
-    #             false don't load,
-    #             true load immediately, wait for complete indexing
-    def DataMagic.init(options = {})
-      logger.info "--"*20
-      logger.info "    DataMagic init VCAP_APPLICATION=#{ENV['VCAP_APPLICATION'].inspect}"
-      logger.info "--"*20
-      logger.info "options: #{options.inspect}"
-      logger.info "self.config: #{self.config.inspect}"
-      if self.config.nil?   # only init once
-        ::Aws.eager_autoload!       # see https://github.com/aws/aws-sdk-ruby/issues/833
-        self.config = Config.new(s3: self.s3)    # loads data.yaml
-        self.index_data_if_needed unless options[:load_now] == false
-        @index_thread.join if options[:load_now] and @index_thread
-      end
-    end # init
-
-    # this is only used for testing
-    # it will clean up all indices associated with the loaded data.yaml
-    def DataMagic.destroy
-      logger.info "DataMagic.destroy"
-      @index_thread.join unless @index_thread.nil?   # finish up indexing, if needed
-      self.config.clear_all unless config.nil?
-      self.config = nil
-    end
-
-end # DataMagic
+  # this is only used for testing
+  # it will clean up all indices associated with the loaded data.yaml
+  def self.destroy
+    logger.info "DataMagic.destroy"
+    @index_thread.join unless @index_thread.nil?   # finish up indexing, if needed
+    self.config.clear_all unless config.nil?
+    self.config = nil
+  end
+end

--- a/lib/data_magic.rb
+++ b/lib/data_magic.rb
@@ -12,6 +12,7 @@ require 'logger'
 require_relative 'data_magic/config'
 require_relative 'data_magic/index'
 require_relative 'data_magic/query_builder'
+require_relative 'data_magic/error_checker'
 require_relative 'zipcode/zipcode'
 
 SafeYAML::OPTIONS[:default_mode] = :safe
@@ -62,6 +63,9 @@ module DataMagic
   # thin layer on elasticsearch query
   def self.search(terms, options = {})
     terms = IndifferentHash.new(terms)
+    errors = ErrorChecker.check(terms, options, config)
+    return { errors: errors } if errors.length > 0
+
     query_body = QueryBuilder.from_params(terms, options, config)
     index_name = index_name_from_options(options)
     logger.info "search terms:#{terms.inspect}"

--- a/lib/data_magic/config.rb
+++ b/lib/data_magic/config.rb
@@ -26,6 +26,14 @@ module DataMagic
       end
     end
 
+    def options
+      @data['options']
+    end
+
+    def dictionary_only_search?
+      options[:search] == 'dictionary_only'
+    end
+
     def examples
       if @examples.nil?
         api = api_endpoint_names[0]
@@ -283,7 +291,7 @@ module DataMagic
         logger.debug "--------> new config -> new index: #{@data.inspect[0..255]}"
         DataMagic.client.indices.delete index: index_name if index_exists
         DataMagic.create_index(index_name, field_types)  ## DataMagic::Index.create ?
-        DataMagic.client.index index: index_name, type:'config', id: 1, body: @data
+        DataMagic.client.index index: index_name, type: 'config', id: 1, body: @data
         updated = true
       end
       updated

--- a/lib/data_magic/error_checker.rb
+++ b/lib/data_magic/error_checker.rb
@@ -13,7 +13,8 @@ module DataMagic
       private
 
       def report_nonexistent_params(params, config)
-        params.keys.reject { |p| config.field_types.key?(p.sub(/__\w+$/, '')) }.
+        return [] unless config.dictionary_only_search?
+        params.keys.reject { |p| config.field_type(p.sub(/__\w+$/, '')) }.
           map { |p| build_error(error: 'parameter_not_found', input: p.sub(/__\w+$/, '')) }
       end
 
@@ -26,8 +27,8 @@ module DataMagic
       end
 
       def report_nonexistent_fields(fields, config)
-        if fields && !fields.empty?
-          fields.reject { |f| config.field_types.key?(f.to_s) }.
+        if fields && !fields.empty? && config.dictionary_only_search?
+          fields.reject { |f| config.field_type(f.to_s) }.
             map { |f| build_error(error: 'field_not_found', input: f.to_s) }
         else
           []

--- a/lib/data_magic/error_checker.rb
+++ b/lib/data_magic/error_checker.rb
@@ -35,10 +35,6 @@ module DataMagic
         end
       end
 
-      def report_bad_sort_argument(options)
-        []
-      end
-
       def report_bad_range_argument(params)
         ranges = params.select do |p,v|
           p =~ /__range$/ and

--- a/lib/data_magic/error_checker.rb
+++ b/lib/data_magic/error_checker.rb
@@ -1,0 +1,78 @@
+module DataMagic
+  module ErrorChecker
+    class << self
+      def check(params, options, config)
+        report_nonexistent_params(params, config) +
+          report_nonexistent_operators(params) +
+          report_nonexistent_fields(options[:fields], config) +
+          report_bad_sort_argument(options) +
+          report_bad_range_argument(params) +
+          report_wrong_field_type(params, config)
+      end
+
+      private
+
+      def report_nonexistent_params(params, config)
+        params.keys.reject { |p| config.field_types.key?(p.sub(/__\w+$/, '')) }.
+          map { |p| build_error(error: 'parameter_not_found', input: p.sub(/__\w+$/, '')) }
+      end
+
+      def report_nonexistent_operators(params)
+        params.keys.select { |p| p =~ /__(\w+)$/ && $1 !~ /range|not|ne/i }.
+          map do |p|
+            (param, op) = p.match(/^(.*)__(\w+)$/).captures
+            build_error(error: 'operator_not_found', parameter: param, input: op)
+          end
+      end
+
+      def report_nonexistent_fields(fields, config)
+        if fields && !fields.empty?
+          fields.reject { |f| config.field_types.key?(f.to_s) }.
+            map { |f| build_error(error: 'field_not_found', input: f.to_s) }
+        else
+          []
+        end
+      end
+
+      def report_bad_sort_argument(options)
+        []
+      end
+
+      def report_bad_range_argument(params)
+        ranges = params.select do |p,v|
+          p =~ /__range$/ and
+            v !~ / ^(\d+(\.\d+)?)? # optional starting number
+                   \.\.           # range dots
+                   (\d+(\.\d+))?  # optional ending number
+                   (,(\d+(\.\d+)?)?\.\.(\d+(\.\d+)?)?)* # and more, with commas
+                   $/x
+        end
+        ranges.map do |p,v|
+          param = p.sub("__range",'')
+          build_error(error: 'range_format_error', parameter: param, input: v)
+        end
+      end
+
+      def report_wrong_field_type(params, config)
+        []
+      end
+
+      def build_error(opts)
+        opts[:message] =
+          case opts[:error]
+          when 'parameter_not_found'
+            "The input parameter '#{opts[:input]}' is not known in this dataset."
+          when 'field_not_found'
+            "The input field '#{opts[:input]}' (in the fields parameter) is not a field in this dataset."
+          when 'operator_not_found'
+            "The input operator '#{opts[:input]}' (appended to the parameter '#{opts[:parameter]}') is not known or supported. (Known operators: range, ne, not)"
+          when 'parameter_type_error'
+            "The parameter '#{opts[:parameter]}' expects a value of type #{opts[:expected_type]}, but received '#{opts[:input]}' which is a value of type #{opts[:input_type]}."
+          when 'range_format_error'
+            "The range '#{opts[:input]}' supplied to parameter '#{opts[:parameter]}' isn't in the correct format."
+          end
+        opts
+      end
+    end
+  end
+end

--- a/lib/data_magic/error_checker.rb
+++ b/lib/data_magic/error_checker.rb
@@ -5,7 +5,6 @@ module DataMagic
         report_nonexistent_params(params, config) +
           report_nonexistent_operators(params) +
           report_nonexistent_fields(options[:fields], config) +
-          report_bad_sort_argument(options) +
           report_bad_range_argument(params) +
           report_wrong_field_type(params, config)
       end

--- a/lib/data_magic/index.rb
+++ b/lib/data_magic/index.rb
@@ -154,7 +154,7 @@ module DataMagic
 
     #logger.debug("field_mapping: #{field_mapping.inspect}")
     options[:mapping] = config.field_mapping
-    options = options.merge(config.data['options'])
+    options = options.merge(config.options)
 
     es_index_name = self.config.load_datayaml(options[:data_path])
     logger.info "creating #{es_index_name}"   # TO DO: fix #14

--- a/sample-data/data.yaml
+++ b/sample-data/data.yaml
@@ -8,6 +8,10 @@ version: cities100-2010
 index: city-data
 api: cities
 unique: ['name']
+
+options:
+  search: dictionary_only   # API provides error when requesting fields not in dictionary
+
 dictionary:
   id:
     source: GEOID

--- a/spec/features/api_spec.rb
+++ b/spec/features/api_spec.rb
@@ -69,6 +69,20 @@ describe 'api', type: 'feature' do
       expect(json_response).to eq(expected)
     end
 
+    it "raises a 400 on a bad query" do
+      expected = {
+        "errors" => [{
+          "error" => 'parameter_not_found',
+          "message" => "The input parameter 'frog' is not known in this dataset.",
+          "input" => 'frog'
+        }]
+      }
+      get "/v1/cities?frog=toad"
+      expect(last_response.status).to eq(400)
+      expect(last_response.content_type).to eq('application/json')
+      expect(json_response).to eq(expected)
+    end
+
     describe "data description" do
       before do
         get '/v1/data.json'

--- a/spec/features/api_spec.rb
+++ b/spec/features/api_spec.rb
@@ -72,12 +72,13 @@ describe 'api', type: 'feature' do
     it "raises a 400 on a bad query" do
       expected = {
         "errors" => [{
-          "error" => 'parameter_not_found',
-          "message" => "The input parameter 'frog' is not known in this dataset.",
-          "input" => 'frog'
+          "error" => 'operator_not_found',
+          "parameter" => "frog",
+          "input" => "blah",
+          "message" => "The input operator 'blah' (appended to the parameter 'frog') is not known or supported. (Known operators: range, ne, not)"
         }]
       }
-      get "/v1/cities?frog=toad"
+      get "/v1/cities?frog__blah=toad"
       expect(last_response.status).to eq(400)
       expect(last_response.content_type).to eq('application/json')
       expect(json_response).to eq(expected)

--- a/spec/fixtures/nested2/data.yaml
+++ b/spec/fixtures/nested2/data.yaml
@@ -8,6 +8,7 @@ options:
 #  columns: all
   limit_files: 1
   limit_rows: 100
+  search: dictionary_only
 
 dictionary:
   id:

--- a/spec/fixtures/nested_files/data.yaml
+++ b/spec/fixtures/nested_files/data.yaml
@@ -10,7 +10,7 @@ dictionary:
     type: literal
   city: CITY_MAIN
   state: STABBR_MAIN
-  zip: ZIP_MAIN
+  zipcode: ZIP_MAIN
   sat_average: SAT_AVG
   location.lat: LATITUDE_MAIN
   location.lon: LONGITUDE_MAIN

--- a/spec/lib/data_magic/config_spec.rb
+++ b/spec/lib/data_magic/config_spec.rb
@@ -81,7 +81,7 @@ describe DataMagic::Config do
         "index" => "city-data", "api" => "cities",
         "files" => [{ "name" => "cities100.csv" }],
         "data_path" => "./sample-data",
-        "options" => {},
+        "options" => {:search=>"dictionary_only"},
         "unique" => ["name"]
       }
       expect(config.data.keys).to include('dictionary')

--- a/spec/lib/data_magic/error_checker_spec.rb
+++ b/spec/lib/data_magic/error_checker_spec.rb
@@ -1,0 +1,123 @@
+require 'spec_helper'
+require 'fixtures/data.rb'
+
+describe 'API errors', type: 'feature' do
+  let(:errors)          {  DataMagic::ErrorChecker.check(params, options, config) }
+  let(:expected_errors) { [] }
+  let(:config)          { DataMagic.config }
+  let(:options)         { {} }
+  let(:params)          { {} }
+
+  before :all do
+    DataMagic.destroy
+    ENV['DATA_PATH'] = './spec/fixtures/sample-data'
+    DataMagic.init(load_now: true)
+  end
+  after :all do
+    DataMagic.destroy
+  end
+
+  RSpec.configure do |c|
+    c.alias_it_should_behave_like_to :it_correctly, ', it correctly'
+  end
+
+  shared_examples "returns an error" do
+    it "with the right content" do
+      expect(errors).to eq expected_errors
+    end
+  end
+
+  describe "are returned" do
+    context "when an unknown parameter is provided" do
+      let(:params) { { "frog" => "toad" } }
+      let(:expected_errors) do
+        [{
+          error: 'parameter_not_found',
+          message: "The input parameter 'frog' is not known in this dataset.",
+          input: 'frog'
+        }]
+      end
+      it_correctly "returns an error"
+    end
+
+    context "when an unknown field is specified in the field list" do
+      let(:options) { { fields: %w(state marjorie) } }
+      let(:expected_errors) do
+        [{
+          error: 'field_not_found',
+          input: 'marjorie',
+          message: "The input field 'marjorie' (in the fields parameter) is not a field in this dataset."
+        }]
+      end
+      it_correctly "returns an error"
+    end
+
+    context "when an unknown operator is used" do
+      let(:params) { { "population__brak" => "1200" } }
+      let(:expected_errors) do
+        [{
+          error: 'operator_not_found',
+          message: "The input operator 'brak' (appended to the parameter 'population') is not known or supported. (Known operators: range, ne, not)",
+          input: 'brak',
+          parameter: 'population'
+        }]
+      end
+      it_correctly "returns an error"
+    end
+
+    context "when a value of the wrong type is provided for a field" do
+      let(:params) { { "population" => "kevin" } }
+      let(:expected_errors) do
+        [{
+          error: 'parameter_type_error',
+          message: "The parameter 'population' expects an integer, but received a string.",
+          input: 'kevin',
+          parameter: 'population',
+          expected_type: 'integer',
+          input_type: 'string'
+        }]
+      end
+      # Pending
+      # it_correctly "returns an error"
+    end
+
+    context "when a range is specified incorrectly" do
+      let(:params) { { "population__range" => "kevin..3" } }
+      let(:expected_errors) do
+        [{
+          error: 'range_format_error',
+          message: "The range 'kevin..3' supplied to parameter 'population' isn't in the correct format.",
+          input: 'kevin..3',
+          parameter: 'population'
+        }]
+      end
+      it_correctly "returns an error"
+    end
+
+    context "when multiple errors occur" do
+      let(:params)  { { "population__range" => "kevin..3" } }
+      let(:options) { { fields: %w(state frog marjorie) } }
+      let(:expected_errors) do
+        [
+          {
+            error: 'field_not_found',
+            message: "The input field 'frog' (in the fields parameter) is not a field in this dataset.",
+            input: 'frog'
+          }, {
+            error: 'field_not_found',
+            message: "The input field 'marjorie' (in the fields parameter) is not a field in this dataset.",
+            input: 'marjorie'
+          }, {
+            error: 'range_format_error',
+            message: "The range 'kevin..3' supplied to parameter 'population' isn't in the correct format.",
+            input: 'kevin..3',
+            parameter: 'population'
+          }
+        ]
+      end
+      # NOTE: This currently also asserts the ordering of errors in the JSON
+      # response, which it shouldn't, because that doesn't matter.
+      it_correctly "returns an error"
+    end
+  end
+end

--- a/spec/lib/data_magic/error_checker_spec.rb
+++ b/spec/lib/data_magic/error_checker_spec.rb
@@ -88,19 +88,35 @@ describe 'API errors', type: 'feature' do
     end
 
     context "when a value of the wrong type is provided for a field" do
-      let(:params) { { "population" => "kevin" } }
-      let(:expected_errors) do
-        [{
-          error: 'parameter_type_error',
-          message: "The parameter 'population' expects an integer, but received a string.",
-          input: 'kevin',
-          parameter: 'population',
-          expected_type: 'integer',
-          input_type: 'string'
-        }]
+      context "providing a string for an integer" do
+        let(:params) { { "population" => "kevin" } }
+        let(:expected_errors) do
+          [{
+            error: 'parameter_type_error',
+            message: "The parameter 'population' expects a value of type integer, but received 'kevin' which is a value of type string.",
+            input: 'kevin',
+            parameter: 'population',
+            expected_type: 'integer',
+            input_type: 'string'
+          }]
+        end
+        it_correctly "returns an error"
       end
-      # Pending
-      # it_correctly "returns an error"
+
+      context "providing a float for an integer, with negation" do
+        let(:params) { { "population__not" => "-123.00" } }
+        let(:expected_errors) do
+          [{
+            error: 'parameter_type_error',
+            message: "The parameter 'population__not' expects a value of type integer, but received '-123.00' which is a value of type float.",
+            input: '-123.00',
+            parameter: 'population__not',
+            expected_type: 'integer',
+            input_type: 'float'
+          }]
+        end
+        it_correctly "returns an error"
+      end
     end
 
     context "when a range is specified incorrectly" do

--- a/spec/lib/data_magic/error_checker_spec.rb
+++ b/spec/lib/data_magic/error_checker_spec.rb
@@ -27,6 +27,12 @@ describe 'API errors', type: 'feature' do
     end
   end
 
+  shared_examples "does not return an error" do
+    it "" do
+      expect(errors).to eq []
+    end
+  end
+
   describe "are returned" do
     context "when an unknown parameter is provided" do
       let(:params) { { "frog" => "toad" } }
@@ -37,7 +43,15 @@ describe 'API errors', type: 'feature' do
           input: 'frog'
         }]
       end
-      it_correctly "returns an error"
+      context "and dictionary-only-search is on" do
+        before do
+          allow(config).to receive(:dictionary_only_search?).and_return(true)
+        end
+        it_correctly "returns an error"
+      end
+      context "and dictionary-only-search is off" do
+        it_correctly "does not return an error"
+      end
     end
 
     context "when an unknown field is specified in the field list" do
@@ -49,7 +63,15 @@ describe 'API errors', type: 'feature' do
           message: "The input field 'marjorie' (in the fields parameter) is not a field in this dataset."
         }]
       end
-      it_correctly "returns an error"
+      context "and dictionary-only-search is on" do
+        before do
+          allow(config).to receive(:dictionary_only_search?).and_return(true)
+        end
+        it_correctly "returns an error"
+      end
+      context "and dictionary-only-search is off" do
+        it_correctly "does not return an error"
+      end
     end
 
     context "when an unknown operator is used" do
@@ -114,6 +136,9 @@ describe 'API errors', type: 'feature' do
             parameter: 'population'
           }
         ]
+      end
+      before do
+        allow(config).to receive(:dictionary_only_search?).and_return(true)
       end
       # NOTE: This currently also asserts the ordering of errors in the JSON
       # response, which it shouldn't, because that doesn't matter.

--- a/spec/lib/data_magic/import_with_nested_files_spec.rb
+++ b/spec/lib/data_magic/import_with_nested_files_spec.rb
@@ -30,7 +30,7 @@ describe "unique key(s)" do
       end
     end
     it "and doesn't include extra field" do
-      expect(first['zip']).to be(nil)
+      expect(first['zipcode']).to be(nil)
     end
   end
 

--- a/spec/lib/data_magic/import_with_nested_files_spec.rb
+++ b/spec/lib/data_magic/import_with_nested_files_spec.rb
@@ -24,7 +24,7 @@ describe "unique key(s)" do
 
   context "can import a subset of fields" do
     context "and when searching for a field value" do
-      let(:query) { {zip: "35762"} }
+      let(:query) { {zipcode: "35762"} }
       it "and doesn't find column" do
         expect(total).to eq(0)
       end

--- a/spec/lib/data_magic/query_builder_spec.rb
+++ b/spec/lib/data_magic/query_builder_spec.rb
@@ -18,35 +18,34 @@ describe DataMagic::QueryBuilder do
     c.alias_it_should_behave_like_to :it_correctly, 'correctly:'
   end
 
-  let(:expected_meta) { { from:0, size:20, _source: { exclude: [ "_*" ]}}}
-  let(:options) { { } }
+  let(:expected_meta) { { from: 0, size: 20, _source: { exclude: ["_*"] } } }
+  let(:options) { {} }
   let(:query_hash) { DataMagic::QueryBuilder.from_params(subject, options, DataMagic.config) }
 
   shared_examples "builds a query" do
-
     it "with a query section" do
       expect(query_hash[:query]).to eql expected_query
     end
     it "with query metadata" do
-      expect(query_hash.reject {|k,v| k == :query }).to eql expected_meta
+      expect(query_hash.reject { |k, _| k == :query }).to eql expected_meta
     end
   end
 
   describe "can issue a blank query" do
-    subject { { } }
+    subject { {} }
     let(:expected_query) { { match_all: {} } }
     it_correctly "builds a query"
   end
 
   describe "can exact match on a field" do
-    subject { {state: "CA"} }
-    let(:expected_query) { { match: {"state" => {query: "CA"} } } }
+    subject { { zipcode: "35762" } }
+    let(:expected_query) { { match: { "zipcode" => { query: "35762" } } } }
     it_correctly "builds a query"
   end
 
   describe "can exact match on a nested field" do
-    subject { {'school.zip': "35762"} }
-    let(:expected_query) { { match: {"school.zip" => {query: "35762"} } } }
+    subject { { 'school.zip': "35762" } }
+    let(:expected_query) { { match: { "school.zip" => { query: "35762" } } } }
     it_correctly "builds a query"
   end
 
@@ -54,13 +53,14 @@ describe DataMagic::QueryBuilder do
     before do
       allow(DataMagic.config).to receive(:field_type).with(:city).and_return("name")
     end
-    subject { {city: "new YORK"} }
+    subject { { city: "new YORK" } }
     let(:expected_query) { { wildcard: { "_city" => { value: "new* york*" } } } }
     it_correctly "builds a query"
   end
 
   describe "can search within a location" do
-    subject { { zip: "94132", distance: "30mi" } }
+    subject { {} }
+    let(:options) { { zip: "94132", distance: "30mi" } }
     let(:expected_query) do {
       filtered: {
         query: { match_all: {} },
@@ -74,32 +74,38 @@ describe DataMagic::QueryBuilder do
   end
 
   describe "can handle pagination" do
-    subject { { page: 3, per_page: 11 } }
+    subject { {} }
+    let(:options) { { page: 3, per_page: 11 } }
     let(:expected_query) { { match_all: {} } }
     let(:expected_meta)  { { from: 33, size: 11, _source: { exclude: [ "_*" ]}}}
     it_correctly "builds a query"
   end
 
   describe "can specify sort order" do
-    subject { { } }
+    subject { {} }
     let(:options) { { sort: "population:asc" } }
     let(:expected_query) { { match_all: {} } }
-    let(:expected_meta)  { { from: 0, size: 20,
-                             _source: { exclude: [ "_*" ] },
-                             sort: [{ "population" => {order: "asc"} }] } }
+    let(:expected_meta)  do
+      { from: 0, size: 20,
+        _source: { exclude: ["_*"] },
+        sort: [{ "population" => { order: "asc" } }]
+      }
+    end
     it_correctly "builds a query"
   end
 
   describe "can sort by multiple fields" do
-    subject { { } }
+    subject { {} }
     let(:options) { { sort: "state:desc, population:asc,name" } }
     let(:expected_query) { { match_all: {} } }
-    let(:expected_meta)  { { from: 0, size: 20,
-                             _source: { exclude: [ "_*" ] },
-                             sort: [{'state' => {order: 'desc'}},
-                                    { "population" => {order: "asc"} },
-                                    { 'name' => {order: 'asc'}}]
-                          } }
+    let(:expected_meta)  do
+      { from: 0, size: 20,
+        _source: { exclude: ["_*"] },
+        sort: [{ 'state' => { order: 'desc' } },
+               { "population" => { order: "asc" } },
+               { 'name' => { order: 'asc' } }]
+      }
+    end
     it_correctly "builds a query"
   end
 
@@ -110,8 +116,8 @@ describe DataMagic::QueryBuilder do
         filtered: {
           query: { match_all: {} },
           filter: {
-            or: [ { range: { age: { gte: 10 } } } ]
-        } } }
+            or: [{ range: { age: { gte: 10 } } }]
+          } } }
       end
       it_correctly "builds a query"
     end
@@ -122,8 +128,8 @@ describe DataMagic::QueryBuilder do
         filtered: {
           query: { match_all: {} },
           filter: {
-            or: [ { range: { age: { lte: 10 } } } ]
-        } } }
+            or: [{ range: { age: { lte: 10 } } }]
+          } } }
       end
       it_correctly "builds a query"
     end
@@ -134,7 +140,7 @@ describe DataMagic::QueryBuilder do
         filtered: {
           query: { match_all: {} },
           filter: {
-            or: [ { range: { age: { gte: 10, lte: 20 } } } ]
+            or: [{ range: { age: { gte: 10, lte: 20 } } }]
         } } }
       end
       it_correctly "builds a query"
@@ -150,7 +156,7 @@ describe DataMagic::QueryBuilder do
               { range: { age: { gte: 10, lte: 20 } } },
               { range: { age: { gte: 30, lte: 40 } } }
             ]
-        } } }
+          } } }
       end
       it_correctly "builds a query"
     end

--- a/spec/lib/data_magic/search_spec.rb
+++ b/spec/lib/data_magic/search_spec.rb
@@ -70,7 +70,7 @@ describe "DataMagic #search" do
 
 
       it "supports pagination" do
-        result = DataMagic.search({address: "Lane", page:1, per_page: 3})
+        result = DataMagic.search({ address: "Lane" }, page:1, per_page: 3)
         expect(result['metadata']["per_page"]).to eq(3)
         expect(result['metadata']["page"]).to eq(1)
         expect(result["results"].length).to eq(1)
@@ -117,14 +117,14 @@ describe "DataMagic #search" do
     end
 
     it "#search can find an attribute" do
-      sfo_location = { lat: 37.615223, lon:-122.389977 }
+      sfo_location = { lat: 37.615223, lon: -122.389977 }
       DataMagic.logger.debug "sfo_location[:lat] #{sfo_location[:lat].class} #{sfo_location[:lat].inspect}"
-      search_terms = {distance:"100mi", zip:"94102"}
-      result = DataMagic.search(search_terms)
+      search_options = { distance: "100mi", zip: "94102" }
+      result = DataMagic.search({}, search_options)
       result["results"] = result["results"].sort_by { |k| k["city"] }
       expected["results"] = [
-        {"city" => "San Francisco", "location"=>{"lat"=>37.727239, "lon"=>-123.032229}},
-        {"city" => "San Jose",      "location"=>{"lat"=>37.296867, "lon"=>-121.819306}}
+        { "city" => "San Francisco", "location" => { "lat" => 37.727239, "lon" => -123.032229 } },
+        { "city" => "San Jose",      "location" => { "lat" => 37.296867, "lon" => -121.819306 } }
       ]
       expected['metadata']["total"] = expected["results"].length
       expect(result).to eq(expected)


### PR DESCRIPTION
Calling this "part 1" because there are still errors not yet handled (in which case, it'll just blow up with a 500 as usual) but @ultrasaurus agreed that Some Error Handling is better than none.

The ErrorChecker module scans the arguments sent to search and looks for badness. It compiles an array of error hashes, each of which includes an `error` code, a human readable `message`, the problematic `input`, and in certain cases some other entries with additional data. (See `spec/lib/data_magic/error_checker_spec.rb` for examples)

If the ErrorChecker finds errors, the API will return HTTP 400 along with a JSON object with the errors array under `errors`.

Errors currently handled:
 * Parameter not found
 * Field not found (in a `fields` parameter)
 * Operator not found (if not `range`, `ne` or `not`)
 * Range format error

Not yet handled:
 * Parameter type error
 * Range type error
 * Bad sort argument
 * Anything to do with geodata, zipcodes, distance etc.
