### PR TITLE
Case insensitve search

### DIFF
--- a/lib/data_magic.rb
+++ b/lib/data_magic.rb
@@ -152,6 +152,7 @@ module DataMagic
       custom_type = {
         'literal' => {type: 'string', index:'not_analyzed'},
         'name' => {type: 'string', index:'not_analyzed'},
+        'lowercase_name' => {type: 'string', index:'not_analyzed', store: false},
      }
       field_types.each_with_object({}) do |(key, type), result|
         result[key] = custom_type[type]

--- a/lib/data_magic/config.rb
+++ b/lib/data_magic/config.rb
@@ -252,6 +252,9 @@ module DataMagic
           type = nil if field_name == 'location.lat' || field_name == 'location.lon'
           #logger.info "field #{field_name}: #{type.inspect}"
           @field_types[field_name] = type unless type.nil?
+          if type == 'name'
+            @field_types["_#{field_name}"] = 'lowercase_name'
+          end
         end
       end
       @field_types

--- a/lib/data_magic/index.rb
+++ b/lib/data_magic/index.rb
@@ -192,6 +192,7 @@ private
       if new_key
         value = value.to_f if new_key.include? "location"
         mapped[new_key] = value
+        mapped["_#{new_key}"] = value.downcase if config.field_type(new_key) == "name"
       elsif options[:columns] == 'all'
         mapped[key] = value
       end
@@ -208,6 +209,8 @@ private
         value.to_f
       when "integer"
         value.to_i
+      when "lowercase_name"
+        value.to_s.downcase   # used for searching
       else # "string"
         value.to_s
     end

--- a/lib/data_magic/query_builder.rb
+++ b/lib/data_magic/query_builder.rb
@@ -6,6 +6,9 @@ module DataMagic
         per_page = params.delete(:per_page) || config.page_size
         page = params.delete(:page).to_i || 0
         query_hash = {
+          _source: {
+            exclude: [ "_*" ]
+          },
           from:   page * per_page.to_i,
           size:   per_page.to_i
         }

--- a/spec/lib/data_magic/name_type_spec.rb
+++ b/spec/lib/data_magic/name_type_spec.rb
@@ -33,7 +33,7 @@ describe "DataMagic name types" do
       [{"city.name"=>"San Francisco"}])
   end
 
-  xit "is not case sensitive" do
+  it "is not case sensitive" do
     response = DataMagic.search({'city.name' => 'new'}, fields:['city.name'])
     results = response['results'].sort {|a,b| a['city.name'] <=> b['city.name']}
     expect(results).to eq(

--- a/spec/lib/data_magic/name_type_spec.rb
+++ b/spec/lib/data_magic/name_type_spec.rb
@@ -34,7 +34,7 @@ describe "DataMagic name types" do
   end
 
   it "is not case sensitive" do
-    response = DataMagic.search({'city.name' => 'new'}, fields:['city.name'])
+    response = DataMagic.search({'city.name' => 'nEW'}, fields:['city.name'])
     results = response['results'].sort {|a,b| a['city.name'] <=> b['city.name']}
     expect(results).to eq(
       [{"city.name"=>"New Orleans"}, {"city.name"=>"New York"}])

--- a/spec/lib/data_magic/query_builder_spec.rb
+++ b/spec/lib/data_magic/query_builder_spec.rb
@@ -18,7 +18,7 @@ describe DataMagic::QueryBuilder do
     c.alias_it_should_behave_like_to :it_correctly, 'correctly:'
   end
 
-  let(:expected_meta) { { from:0, size:20 } }
+  let(:expected_meta) { { from:0, size:20, _source: { exclude: [ "_*" ]}}}
   let(:options) { { } }
   let(:query_hash) { DataMagic::QueryBuilder.from_params(subject, options, DataMagic.config) }
 
@@ -67,7 +67,7 @@ describe DataMagic::QueryBuilder do
   describe "can handle pagination" do
     subject { { page: 3, per_page: 11 } }
     let(:expected_query) { { match_all: {} } }
-    let(:expected_meta)  { { from: 33, size: 11 } }
+    let(:expected_meta)  { { from: 33, size: 11, _source: { exclude: [ "_*" ]}}}
     it_correctly "builds a query"
   end
 
@@ -75,7 +75,9 @@ describe DataMagic::QueryBuilder do
     subject { { } }
     let(:options) { { sort: "population:asc" } }
     let(:expected_query) { { match_all: {} } }
-    let(:expected_meta)  { { from: 0, size: 20, sort: [{ "population" => {order: "asc"} }] } }
+    let(:expected_meta)  { { from: 0, size: 20,
+                             _source: { exclude: [ "_*" ] },
+                             sort: [{ "population" => {order: "asc"} }] } }
     it_correctly "builds a query"
   end
 
@@ -83,7 +85,12 @@ describe DataMagic::QueryBuilder do
     subject { { } }
     let(:options) { { sort: "state:desc, population:asc,name" } }
     let(:expected_query) { { match_all: {} } }
-    let(:expected_meta)  { { from: 0, size: 20, sort: [{'state' => {order: 'desc'}}, { "population" => {order: "asc"} }, { 'name' => {order: 'asc'}}] } }
+    let(:expected_meta)  { { from: 0, size: 20,
+                             _source: { exclude: [ "_*" ] },
+                             sort: [{'state' => {order: 'desc'}},
+                                    { "population" => {order: "asc"} },
+                                    { 'name' => {order: 'asc'}}]
+                          } }
     it_correctly "builds a query"
   end
 

--- a/spec/lib/data_magic/query_builder_spec.rb
+++ b/spec/lib/data_magic/query_builder_spec.rb
@@ -39,14 +39,23 @@ describe DataMagic::QueryBuilder do
   end
 
   describe "can exact match on a field" do
-    subject { {zip: "35762"} }
-    let(:expected_query) { { match: {"zip" => {query: "35762"} } } }
+    subject { {state: "CA"} }
+    let(:expected_query) { { match: {"state" => {query: "CA"} } } }
     it_correctly "builds a query"
   end
 
   describe "can exact match on a nested field" do
     subject { {'school.zip': "35762"} }
     let(:expected_query) { { match: {"school.zip" => {query: "35762"} } } }
+    it_correctly "builds a query"
+  end
+
+  describe "can case-insensitive match on a field" do
+    before do
+      allow(DataMagic.config).to receive(:field_type).with(:city).and_return("name")
+    end
+    subject { {city: "new YORK"} }
+    let(:expected_query) { { wildcard: { "_city" => { value: "new* york*" } } } }
     it_correctly "builds a query"
   end
 


### PR DESCRIPTION
for every field of type name, this commit indexes two fields
the original text and another that is lowercase and prefixed by _
for example, if we have a field city: New York
then we make another field _city: new york
we search on "_city" but only include "city" in results
