### PR TITLE
fixed indexing of "name" type when files have "only" option

### DIFF
--- a/lib/data_magic/config.rb
+++ b/lib/data_magic/config.rb
@@ -26,6 +26,12 @@ module DataMagic
       end
     end
 
+    # what are the valid types for the configured dictionary to have
+    # we allow type to be blank (nil), which will be interpreted as a String
+    def valid_types
+      @valid_type_config ||= DataMagic.valid_types + [nil]
+    end
+
     def examples
       if @examples.nil?
         api = api_endpoint_names[0]
@@ -180,49 +186,18 @@ module DataMagic
       @field_mapping
     end
 
-    def parse_expression(expression, field_name='unknown')
-      match = /\s*(\w+)\s+or\s+(\w+)\s*/.match expression
-      # logger.debug("parse_expression #{match.inspect}")
-      if match.nil? or match[1].nil? or match[2].nil?
-        raise ArgumentError,
-          "can't interpret #{expression.inspect} for #{field_name}"
-      end
-      [match[1], match[2]]
-    end
-
-    # currently we just support 'or' operations on two columns
-    def calculate(field_name, row)
-      item = dictionary[field_name]
-      #logger.debug("row #{row.inspect}")
-      #logger.debug("calculate item #{item.inspect}")
-      expr = item['calculate']
-      raise ArgumentError, "expected to calculate #{field_name}" if expr.nil?
-      cols = parse_expression(expr, field_name) #if expr.is_a? String
-      cols = cols.map { |c| row[c.to_sym] }
-      cols = cols.map { |value| value == 'NULL' ? nil : value }
-      a, b = cols.map { |c| (DataMagic::fix_field_type(item['type'], c)) }
-      #logger.debug("final: data #{cols.inspect} #{a.inspect} #{b.inspect} #{(a || b).inspect}")
-      a || b
-    end
-
-    def calculated_field_list(row)
+    def calculated_field_list
       if @calculated_field_list.nil?
         @calculated_field_list = []
         dictionary.each do |field_name, info|
-          if info.is_a? Hash and info['calculate']
-            @calculated_field_list << field_name
+          if info.is_a? Hash
+            if info['calculate'] or info[:calculate]
+              @calculated_field_list << field_name.to_s
+            end
           end
         end
       end
       @calculated_field_list
-    end
-
-    def calculated_fields(row)
-      result = {}
-      calculated_field_list(row).each do |name|
-        result[name] = calculate(name, row)
-      end
-      result
     end
 
     def field_type(field_name)
@@ -388,6 +363,10 @@ module DataMagic
       File.basename(uri.hostname || uri.path).gsub(/[^0-9a-z]+/, '-')
     end
 
+    def null_value
+      @data['null_value'] || 'NULL'
+    end
+
     def load_datayaml(directory_path = nil)
       logger.debug "---- Config.load -----"
       if directory_path.nil? or directory_path.empty?
@@ -400,7 +379,6 @@ module DataMagic
         logger.debug "load config #{directory_path.inspect}"
         @data = load_yaml(directory_path)
         @data['unique'] ||= []
-        @null_value = @data['null_value'] || 'NULL'
         logger.debug "config: #{@data.inspect[0..600]}"
         @data['index'] ||= clean_index(@data_path)
         endpoint = @data['api'] || clean_index(@data_path)

--- a/lib/data_magic/document_builder.rb
+++ b/lib/data_magic/document_builder.rb
@@ -6,64 +6,56 @@ module DataMagic
       def logger
         DataMagic::Config.logger
       end
+
       # parse a row from a csv file, returns a nested document
       # row: a hash  { field => value } where all values are strings
       # fields: column_name => field_name
       # config: DataMagic.Config instance for dictionary, column types, NULL
       def parse_row(row, fields, config, options={}, additional=nil)
         row = csv_row = row.to_hash
-        # logger.debug "row #{row.inspect[0..255]}"
-        # logger.debug "fields #{fields.inspect[0..255]}"
-        # logger.debug "column_field_types #{config.column_field_types.inspect[0..255]}"
-        row = map_field_names(row, fields, config, options) unless fields.empty?
+        row = map_field_names(row, fields, options) unless fields.empty?
         row = row.merge(calculated_fields(csv_row, config))
         unless config.column_field_types.empty? && config.null_value.empty?
           row = map_field_types(row, config.valid_types,
-                                 config.column_field_types,
-                                 config.null_value)
+                                config.column_field_types,
+                                config.null_value)
         end
         row = row.merge(additional) if additional
         doc = NestedHash.new.add(row)
         doc = parse_nested(doc, options) if options[:nest]
         doc = select_only_fields(doc, options[:only]) unless options[:only].nil?
-        #logger.debug "doc #{doc.inspect[0..255]}"
         doc
       end
 
       def calculated_fields(row, config)
         result = {}
-        #logger.info "calculated_fields: #{config.calculated_field_list}"
         config.calculated_field_list.each do |name|
           result[name] = calculate(name, row, config.dictionary)
-          #logger.info "#{name.inspect} #{result[name].inspect}"
         end
         result
       end
-    private
+
+      private
+
       # row: a hash  (keys may be strings or symbols)
       # valid_types: an array of allowed types
       # field_types: hash field_name : type (float, integer, string)
       # returns a hash where values have been coerced to the new type
       def map_field_types(row, valid_types, field_types = {}, null_value = 'NULL')
-        # logger.debug("map_field_types: #{valid_types.inspect} #{field_types.inspect}")
-        # logger.debug("row: #{row.inspect}")
         mapped = {}
         row.each do |key, value|
           if value == null_value
             mapped[key] = nil
           else
             type = field_types[key.to_sym] || field_types[key.to_s]
-            #logger.info "key: #{key} type: #{type}"
             if valid_types.include? type
               mapped[key] = fix_field_type(type, value, key)
               mapped["_#{key}"] = value.downcase if type == "name"
             else
-              raise InvalidDictionary, "unexpected type #{type.inspect} " +
-                "for field #{key}"
+              fail InvalidDictionary, "unexpected type '#{type.inspect}' for field '#{key}'"
             end
           end
         end
-        #logger.info "mappped: #{mapped.inspect}"
         mapped
       end
 
@@ -71,55 +63,43 @@ module DataMagic
         new_doc = {}
         nest_options = options[:nest]
         if nest_options
-          #logger.info "nest: #{nest_options.to_yaml}"
-          #logger.info "add to document: #{document.inspect[0..255]}"
           key = nest_options['key']
           new_doc[key] = {}
-
-          id = document['id']
-          new_doc['id'] = id unless id.nil?
-
+          new_doc['id'] = document['id'] unless document['id'].nil?
           nest_options['contents'].each do |item_key|
-            #logger.info "adding item #{item_key}"
             new_doc[key][item_key] = document[item_key]
           end
         end
-        #logger.info "here it is: #{new_doc}"
         new_doc
       end
 
       def fix_field_type(type, value, key=nil)
-        #logger.info "fix_field_type type:#{type.inspect} value: #{value.inspect} key: #{key.inspect}"
         return value if value.nil?
 
         new_value = case type
-          when "float"
-            value.to_f
-          when "integer"
-            value.to_i
-          when "lowercase_name"
-            value.to_s.downcase   # used for searching
-          else # "string"
-            value.to_s
+                    when "float"
+                      value.to_f
+                    when "integer"
+                      value.to_i
+                    when "lowercase_name"
+                      value.to_s.downcase   # used for searching
+                    else # "string"
+                      value.to_s
         end
         new_value = value.to_f if key and key.to_s.include? "location"
-        #logger.info "new_value #{new_value.inspect}"
         new_value
       end
 
       # currently we just support 'or' operations on two columns
       def calculate(field_name, row, dictionary)
         item = dictionary[field_name.to_s] || dictionary[field_name.to_sym]
-        raise "calculate: field not found in dictionary #{field_name.inspect}" if item.nil?
-        #logger.debug("row #{row.inspect}")
-        #logger.debug("calculate item #{item.inspect}")
+        fail "calculate: field not found in dictionary #{field_name.inspect}" if item.nil?
         expr = item['calculate'] || item[:calculate]
-        raise ArgumentError, "expected to calculate #{field_name}" if expr.nil?
-        cols = Expression.new(expr, field_name).variables #if expr.is_a? String
-        cols = cols.map { |c| row[c.to_sym] }
-        cols = cols.map { |value| value == 'NULL' ? nil : value }
-        a, b = cols.map { |c| (fix_field_type(item['type'], c)) }
-        #logger.debug("final: data #{cols.inspect} #{a.inspect} #{b.inspect} #{(a || b).inspect}")
+        fail ArgumentError, "expected to calculate #{field_name}" if expr.nil?
+        a, b = Expression.new(expr, field_name).variables
+               .map { |c| row[c.to_sym] }
+               .map { |value| value == 'NULL' ? nil : value }
+               .map { |c| (fix_field_type(item['type'], c)) }
         a || b
       end
 
@@ -127,12 +107,11 @@ module DataMagic
       # new_fields: hash current_name : new_name
       # returns a hash (which may be a subset of row) where keys are new_name
       #         with value of corresponding row[current_name]
-      def map_field_names(row, new_fields, config, options={})
+      def map_field_names(row, new_fields, options = {})
         mapped = {}
         row.each do |key, value|
-          raise ArgumentError, "column header missing for: #{value}" if key.nil?
+          fail ArgumentError, "column header missing for: #{value}" if key.nil?
           new_key = new_fields[key.to_sym] || new_fields[key.to_s]
-          #logger.info "key: #{key.inspect}, new_key:#{new_key.inspect}"
           if new_key
             value = value.to_f if new_key.include? "location"
             mapped[new_key] = value

--- a/lib/data_magic/document_builder.rb
+++ b/lib/data_magic/document_builder.rb
@@ -1,0 +1,147 @@
+require './lib/expression'
+
+module DataMagic
+  module DocumentBuilder
+    class << self
+      def logger
+        DataMagic::Config.logger
+      end
+      # parse a row from a csv file, returns a nested document
+      # row: a hash  { field => value } where all values are strings
+      # fields: column_name => field_name
+      # config: DataMagic.Config instance for dictionary, column types, NULL
+      def parse_row(row, fields, config, options={}, additional=nil)
+        row = csv_row = row.to_hash
+        # logger.debug "row #{row.inspect[0..255]}"
+        # logger.debug "column_field_types #{config.column_field_types.inspect[0..255]}"
+        row = map_field_names(row, fields, config, options) unless fields.empty?
+        row = row.merge(calculated_fields(csv_row, config))
+        unless config.column_field_types.empty? && config.null_value.empty?
+          row = map_field_types(row, config.valid_types,
+                                 config.column_field_types,
+                                 config.null_value)
+        end
+        row = row.merge(additional) if additional
+        doc = NestedHash.new.add(row)
+        doc = parse_nested(doc, options) if options[:nest]
+        doc = doc.select {|key, value| options[:only].include?(key) } unless options[:only].nil?
+        # logger.debug "doc #{doc.inspect[0..255]}"
+        doc
+      end
+
+      def calculated_fields(row, config)
+        result = {}
+        #logger.info "calculated_fields: #{config.calculated_field_list}"
+        config.calculated_field_list.each do |name|
+          result[name] = calculate(name, row, config.dictionary)
+          #logger.info "#{name.inspect} #{result[name].inspect}"
+        end
+        result
+      end
+    private
+      # row: a hash  (keys may be strings or symbols)
+      # valid_types: an array of allowed types
+      # field_types: hash field_name : type (float, integer, string)
+      # returns a hash where values have been coerced to the new type
+      def map_field_types(row, valid_types, field_types = {}, null_value = 'NULL')
+        # logger.debug("map_field_types: #{valid_types.inspect} #{field_types.inspect}")
+        # logger.debug("row: #{row.inspect}")
+        mapped = {}
+        row.each do |key, value|
+          if value == null_value
+            mapped[key] = nil
+          else
+            type = field_types[key.to_sym] || field_types[key.to_s]
+            #logger.info "key: #{key} type: #{type}"
+            if valid_types.include? type
+              mapped[key] = fix_field_type(type, value, key)
+              mapped["_#{key}"] = value.downcase if type == "name"
+            else
+              raise InvalidDictionary, "unexpected type #{type.inspect} " +
+                "for field #{key}"
+            end
+          end
+        end
+        #logger.info "mappped: #{mapped.inspect}"
+        mapped
+      end
+
+      def parse_nested(document, options)
+        new_doc = {}
+        nest_options = options[:nest]
+        if nest_options
+          #logger.info "nest: #{nest_options.to_yaml}"
+          #logger.info "add to document: #{document.inspect[0..255]}"
+          key = nest_options['key']
+          new_doc[key] = {}
+
+          id = document['id']
+          new_doc['id'] = id unless id.nil?
+
+          nest_options['contents'].each do |item_key|
+            #logger.info "adding item #{item_key}"
+            new_doc[key][item_key] = document[item_key]
+          end
+        end
+        #logger.info "here it is: #{new_doc}"
+        new_doc
+      end
+
+      def fix_field_type(type, value, key=nil)
+        #logger.info "fix_field_type type:#{type.inspect} value: #{value.inspect} key: #{key.inspect}"
+        return value if value.nil?
+
+        new_value = case type
+          when "float"
+            value.to_f
+          when "integer"
+            value.to_i
+          when "lowercase_name"
+            value.to_s.downcase   # used for searching
+          else # "string"
+            value.to_s
+        end
+        new_value = value.to_f if key and key.to_s.include? "location"
+        #logger.info "new_value #{new_value.inspect}"
+        new_value
+      end
+
+      # currently we just support 'or' operations on two columns
+      def calculate(field_name, row, dictionary)
+        item = dictionary[field_name.to_s] || dictionary[field_name.to_sym]
+        raise "calculate: field not found in dictionary #{field_name.inspect}" if item.nil?
+        #logger.debug("row #{row.inspect}")
+        #logger.debug("calculate item #{item.inspect}")
+        expr = item['calculate'] || item[:calculate]
+        raise ArgumentError, "expected to calculate #{field_name}" if expr.nil?
+        cols = Expression.new(expr, field_name).variables #if expr.is_a? String
+        cols = cols.map { |c| row[c.to_sym] }
+        cols = cols.map { |value| value == 'NULL' ? nil : value }
+        a, b = cols.map { |c| (fix_field_type(item['type'], c)) }
+        #logger.debug("final: data #{cols.inspect} #{a.inspect} #{b.inspect} #{(a || b).inspect}")
+        a || b
+      end
+
+      # row: a hash  (keys may be strings or symbols)
+      # new_fields: hash current_name : new_name
+      # returns a hash (which may be a subset of row) where keys are new_name
+      #         with value of corresponding row[current_name]
+      def map_field_names(row, new_fields, config, options={})
+        mapped = {}
+        row.each do |key, value|
+          raise ArgumentError, "column header missing for: #{value}" if key.nil?
+          new_key = new_fields[key.to_sym] || new_fields[key.to_s]
+          #logger.info "key: #{key.inspect}, new_key:#{new_key.inspect}"
+          if new_key
+            value = value.to_f if new_key.include? "location"
+            mapped[new_key] = value
+          elsif options[:columns] == 'all'
+            mapped[key] = value
+          end
+        end
+        mapped
+      end
+
+    end # class methods
+  end # module QueryBuilder
+end  # module DataMagic

--- a/lib/expression.rb
+++ b/lib/expression.rb
@@ -2,19 +2,18 @@ class Expression
   attr_accessor :name   # purely for reporting Errors
   attr_reader   :variables
 
-  def initialize(expr, name='unknown')
+  def initialize(expr, name = 'unknown')
     @variables = parse(expr)
   end
 
   private
-    def parse(expression)
-      match = /\s*(\w+)\s+or\s+(\w+)\s*/.match expression
-      # logger.debug("parse_expression #{match.inspect}")
-      if match.nil? or match[1].nil? or match[2].nil?
-        raise ArgumentError,
-          "can't interpret #{expression.inspect} for #{name}"
-      end
-      [match[1], match[2]]
+
+  def parse(expression)
+    match = /\s*(\w+)\s+or\s+(\w+)\s*/.match expression
+    if match.nil? or match[1].nil? or match[2].nil?
+      fail ArgumentError, "can't interpret #{expression.inspect} for #{name}"
     end
+    [match[1], match[2]]
+  end
 
 end

--- a/lib/expression.rb
+++ b/lib/expression.rb
@@ -1,0 +1,20 @@
+class Expression
+  attr_accessor :name   # purely for reporting Errors
+  attr_reader   :variables
+
+  def initialize(expr, name='unknown')
+    @variables = parse(expr)
+  end
+
+  private
+    def parse(expression)
+      match = /\s*(\w+)\s+or\s+(\w+)\s*/.match expression
+      # logger.debug("parse_expression #{match.inspect}")
+      if match.nil? or match[1].nil? or match[2].nil?
+        raise ArgumentError,
+          "can't interpret #{expression.inspect} for #{name}"
+      end
+      [match[1], match[2]]
+    end
+
+end

--- a/spec/lib/data_magic/calculated_columns_spec.rb
+++ b/spec/lib/data_magic/calculated_columns_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'data_magic'
 
-describe "unique key(s)" do
+describe "calculated columns" do
 
   before :example do
     DataMagic.destroy

--- a/spec/lib/data_magic/document_builder_spec.rb
+++ b/spec/lib/data_magic/document_builder_spec.rb
@@ -4,11 +4,11 @@ require 'hashie'
 
 describe DataMagic::DocumentBuilder do
 
-  let(:config) { DataMagic::Config.new(load_datayaml: false) }
-  let(:fields) {{ }}
-  let(:options) {{ }}
-  let(:additional) {{ }}
-  let(:document) { DataMagic::DocumentBuilder.parse_row(subject, fields, config, options, additional) }
+  let(:config)     { DataMagic::Config.new(load_datayaml: false) }
+  let(:fields)     { {} }
+  let(:options)    { {} }
+  let(:additional) { {} }
+  let(:document)   { DataMagic::DocumentBuilder.parse_row(subject, fields, config, options, additional) }
 
   RSpec.configure do |c|
     c.alias_it_should_behave_like_to :it_correctly, 'correctly:'
@@ -22,18 +22,18 @@ describe DataMagic::DocumentBuilder do
 
   context "with no field mapping" do
     describe "strings" do
-      subject {{ city: 'New York', state: 'NY'}}
-      let(:expected_document) {{ 'city'=> 'New York', 'state' => 'NY'}}
+      subject {{ city: 'New York', state: 'NY' }}
+      let(:expected_document) {{ 'city' => 'New York', 'state' => 'NY' }}
       it_correctly "creates a document"
     end
   end
   context "with type mapping" do
     describe "integer" do
       before do
-        allow(config).to receive(:column_field_types).and_return({size: 'integer'})
+        allow(config).to receive(:column_field_types).and_return(size: 'integer')
       end
       subject {{ size: '45' }}
-      let(:expected_document) {{ 'size'=> 45}}
+      let(:expected_document) {{ 'size' => 45}}
       it_correctly "creates a document"
     end
 
@@ -49,7 +49,7 @@ describe DataMagic::DocumentBuilder do
     describe "multiple types" do
       before do
         allow(config).to receive(:column_field_types).and_return(
-          {population: 'integer', elevation: 'float'})
+          population: 'integer', elevation: 'float')
       end
       subject {{ name: 'Smithville', population: '45', elevation: '20.5'  }}
       let(:expected_document) {{ 'name' => 'Smithville',
@@ -61,29 +61,28 @@ describe DataMagic::DocumentBuilder do
     describe "expressions" do
       before do
         allow(config).to receive(:column_field_types).and_return(
-            {one: 'float', two: 'float', one_or_two:'float'} )
+          one: 'float', two: 'float', one_or_two:'float')
         allow(config).to receive(:dictionary).and_return(
-            { one_or_two: {
-                  calculate: 'one or two',
-                  type: 'float',
-                  description: 'something'
-              }
-            } )
+          one_or_two: {
+            calculate: 'one or two',
+            type: 'float',
+            description: 'something'
+          })
       end
       context "with second value NULL" do
-        subject {{ one: '0.12', two:'NULL' }}
-        let(:expected_document)  { { 'one' => 0.12, 'two'=> nil, 'one_or_two'=> 0.12  } }
+        subject {{ one: '0.12', two: 'NULL' }}
+        let(:expected_document)  { { 'one' => 0.12, 'two' => nil, 'one_or_two' => 0.12  } }
         it "reports calculated fields" do
           expect(
             DataMagic::DocumentBuilder.calculated_fields(subject, config)
-          ).to eq(  {'one_or_two' => "0.12"} )
+          ).to eq('one_or_two' => "0.12")
         end
         it_correctly "creates a document"
       end
 
       context "with first value NULL" do
-        subject {{ one: 'NULL', two:'0.45' }}
-        let(:expected_document)  { { 'one'=> nil, 'two'=> 0.45, 'one_or_two'=> 0.45 } }
+        subject {{ one: 'NULL', two: '0.45' }}
+        let(:expected_document)  { { 'one' => nil, 'two' => 0.45, 'one_or_two' => 0.45 } }
         it_correctly "creates a document"
       end
 
@@ -92,15 +91,12 @@ describe DataMagic::DocumentBuilder do
 
   context "with column name mapping" do
     before do
-      config.dictionary =
-          { name: 'NAME',
-            state: 'STABBR'
-          }
+      config.dictionary = { name: 'NAME', state: 'STABBR' }
     end
     let(:fields) { config.field_mapping }
     context "with second value NULL" do
       subject {{ NAME: 'foo', STABBR:'MA' }}
-      let(:expected_document)  { { 'name' => 'foo', 'state'=> 'MA'  } }
+      let(:expected_document)  { { 'name' => 'foo', 'state' => 'MA'  } }
       it_correctly "creates a document"
     end
   end
@@ -110,10 +106,10 @@ describe DataMagic::DocumentBuilder do
       config.dictionary = { id: 'ID',
                             state: 'STABBR',
                             city: {
-                                  source: 'CITY',
-                                  type: 'name'
-                              }
-                           }
+                              source: 'CITY',
+                              type: 'name'
+                            }
+                          }
     end
     let(:fields) { config.field_mapping }
 

--- a/spec/lib/data_magic/document_builder_spec.rb
+++ b/spec/lib/data_magic/document_builder_spec.rb
@@ -1,0 +1,108 @@
+require 'spec_helper'
+require 'data_magic'
+require 'hashie'
+
+describe DataMagic::DocumentBuilder do
+
+  let(:config) { DataMagic::Config.new(load_datayaml: false) }
+  let(:fields) {{ }}
+  let(:options) {{ }}
+  let(:additional) {{ }}
+  let(:document) { DataMagic::DocumentBuilder.parse_row(subject, fields, config, options, additional) }
+
+  RSpec.configure do |c|
+    c.alias_it_should_behave_like_to :it_correctly, 'correctly:'
+  end
+
+  shared_examples "creates a document" do
+    it "with fields" do
+      expect(document).to eql expected_document
+    end
+  end
+
+  context "with no field mapping" do
+    describe "strings" do
+      subject {{ city: 'New York', state: 'NY'}}
+      let(:expected_document) {{ 'city'=> 'New York', 'state' => 'NY'}}
+      it_correctly "creates a document"
+    end
+  end
+  context "with type mapping" do
+    describe "integer" do
+      before do
+        allow(config).to receive(:column_field_types).and_return({size: 'integer'})
+      end
+      subject {{ size: '45' }}
+      let(:expected_document) {{ 'size'=> 45}}
+      it_correctly "creates a document"
+    end
+
+    describe "with name type" do
+      before do
+        config.dictionary =  {city: { source: 'CITY', type: 'name' }}
+      end
+      subject {{ city: 'New York' }}
+      let(:expected_document) {{ 'city' => 'New York', '_city' => 'new york'}}
+      it_correctly "creates a document"
+    end
+
+    describe "multiple types" do
+      before do
+        allow(config).to receive(:column_field_types).and_return(
+          {population: 'integer', elevation: 'float'})
+      end
+      subject {{ name: 'Smithville', population: '45', elevation: '20.5'  }}
+      let(:expected_document) {{ 'name' => 'Smithville',
+                                  'population' => 45,
+                                  'elevation' => 20.5 }}
+      it_correctly "creates a document"
+    end
+
+    describe "expressions" do
+      before do
+        allow(config).to receive(:column_field_types).and_return(
+            {one: 'float', two: 'float', one_or_two:'float'} )
+        allow(config).to receive(:dictionary).and_return(
+            { one_or_two: {
+                  calculate: 'one or two',
+                  type: 'float',
+                  description: 'something'
+              }
+            } )
+      end
+      context "with second value NULL" do
+        subject {{ one: '0.12', two:'NULL' }}
+        let(:expected_document)  { { 'one' => 0.12, 'two'=> nil, 'one_or_two'=> 0.12  } }
+        it "reports calculated fields" do
+          expect(
+            DataMagic::DocumentBuilder.calculated_fields(subject, config)
+          ).to eq(  {'one_or_two' => "0.12"} )
+        end
+        it_correctly "creates a document"
+      end
+
+      context "with first value NULL" do
+        subject {{ one: 'NULL', two:'0.45' }}
+        let(:expected_document)  { { 'one'=> nil, 'two'=> 0.45, 'one_or_two'=> 0.45 } }
+        it_correctly "creates a document"
+      end
+
+    end
+  end
+
+  context "with column name mapping" do
+    before do
+      config.dictionary =
+          { name: 'NAME',
+            state: 'STABBR'
+          }
+    end
+    let(:fields) { config.field_mapping }
+    context "with second value NULL" do
+      subject {{ NAME: 'foo', STABBR:'MA' }}
+      let(:expected_document)  { { 'name' => 'foo', 'state'=> 'MA'  } }
+      it_correctly "creates a document"
+    end
+  end
+
+end

--- a/spec/lib/data_magic/document_builder_spec.rb
+++ b/spec/lib/data_magic/document_builder_spec.rb
@@ -105,4 +105,31 @@ describe DataMagic::DocumentBuilder do
     end
   end
 
+  context "with options[:only]" do
+    before do
+      config.dictionary = { id: 'ID',
+                            state: 'STABBR',
+                            city: {
+                                  source: 'CITY',
+                                  type: 'name'
+                              }
+                           }
+    end
+    let(:fields) { config.field_mapping }
+
+    context "specify two vanilla columns" do
+      let(:options) {{ only: %w[id state] }}
+      subject {{ ID: 'ABC', STABBR: 'NY', CITY: 'New York' }}
+      let(:expected_document) {{ 'id' => 'ABC', 'state' => 'NY'}}
+      it_correctly "creates a document"
+    end
+
+    context "specify name column" do
+      let(:options) {{ only: %w[city] }}
+      subject {{ ID: 'ABC', STABBR: 'NY', CITY: 'New York' }}
+      let(:expected_document) {{ 'city' => 'New York', '_city' => 'new york'}}
+      it_correctly "creates a document"
+    end
+  end
+
 end

--- a/spec/lib/expression_spec.rb
+++ b/spec/lib/expression_spec.rb
@@ -1,0 +1,10 @@
+require 'expression'
+
+describe Expression do
+  context "simple or expression" do
+    it "can find variables" do
+      expr = "ONE or TWO"
+      expect(Expression.new(expr).variables).to eq(%w(ONE TWO))
+    end
+  end
+end


### PR DESCRIPTION
this addresses a bug in PR #165 where case insentive search would fail
if it was for a field specified as part of an "only" configuration

for example, in data.yaml
```
files:
  - name: school-data.csv
    only: [id, name, city, state]
```
would select only the fields id, name, city, and state from that particular file.  
Other files may include other fields in the dictionary.  The bug was that it 
would include name, but omit _name (which is never visible to the user, 
but required for case insensitive indexing.
note: with this option, if dot syntax is used, only top level fields may be specified
