### PR TITLE
[WIP] autocomplete type

### DIFF
--- a/lib/data_magic/index.rb
+++ b/lib/data_magic/index.rb
@@ -148,7 +148,7 @@ module DataMagic
 
 private
   def self.valid_types
-    %w[integer float string literal name]
+    %w[integer float string literal name autocomplete]
   end
 
 end # module DataMagic


### PR DESCRIPTION
indexes lowercase, by 3-25 letters in any word
ignores english “stop words”
searches lowercase, ignoring “stop words”
word boundaries determined by unicode standard text segmentation