### PR TITLE
option parameters should now be underscore-prefixed

### DIFF
--- a/app/controllers.rb
+++ b/app/controllers.rb
@@ -58,20 +58,18 @@ OpenDataMaker::App.controllers :v1 do
 end
 
 # TODO: Use of non-underscore-prefixed option parameters is still
-# supported but deprecated, and should be removed at some point soon
-SUPPORT_DEPRECATED_OPTION_SYNTAX = true
+# supported but deprecated, and should be removed at some point soon -
+# see comment in method body
 def get_search_args_from_params(params)
-  options = {
-    endpoint: params.delete("endpoint"),
-    format:   params.delete("format")
-  }
+  options = {}
   %w(sort fields zip distance page per_page).each do |opt|
-    options[opt.to_sym] = params.delete("_#{opt}") ||
-                          (SUPPORT_DEPRECATED_OPTION_SYNTAX && params.delete(opt))
+    options[opt.to_sym] = params.delete("_#{opt}")
+    # TODO: remove next line to end support for un-prefixed option parameters
+    options[opt.to_sym] ||= params.delete(opt)
   end
+  options[:endpoint] = params.delete("endpoint") # these two params are
+  options[:format]   = params.delete("format")   # supplied by Padrino
   options[:fields]   = (options[:fields]   || "").split(',')
-  options[:per_page] = (options[:per_page] || DataMagic.config.page_size).to_i
-  options[:page]     = (options[:page]     || 0).to_i
   options
 end
 

--- a/lib/data_magic.rb
+++ b/lib/data_magic.rb
@@ -166,16 +166,16 @@ module DataMagic
 
 
   # get the real index name when given either
-  # api: api endpoint configured in data.yaml
+  # endpoint: api endpoint configured in data.yaml
   # index: index name
   def self.index_name_from_options(options)
-    options[:api] = options['api'].to_sym if options['api']
+    api = options[:endpoint]
     options[:index] = options['index'].to_sym if options['index']
-    logger.info "WARNING: DataMagic.search options api will override index, only one expected"  if options[:api] and options[:index]
-    if options[:api]
-      index_name = config.find_index_for(options[:api])
+    logger.info "WARNING: DataMagic.search options api will override index, only one expected"  if api and options[:index]
+    if api
+      index_name = config.find_index_for(api)
       if index_name.nil?
-        raise ArgumentError, "no configuration found for '#{options[:api]}', available endpoints: #{self.config.api_endpoint_names.inspect}"
+        raise ArgumentError, "no configuration found for '#{api}', available endpoints: #{self.config.api_endpoint_names.inspect}"
       end
     else
       index_name = options[:index]

--- a/spec/fixtures/sample-data/data.yaml
+++ b/spec/fixtures/sample-data/data.yaml
@@ -8,6 +8,8 @@ version: cities100-2010
 index: city-data
 api: cities
 unique: ['name']
+options:
+  search: dictionary_only
 
 dictionary:
   state: USPS

--- a/spec/lib/data_magic/error_checker_spec.rb
+++ b/spec/lib/data_magic/error_checker_spec.rb
@@ -34,6 +34,10 @@ describe 'API errors', type: 'feature' do
   end
 
   describe "are returned" do
+    before do
+      allow(config).to receive(:dictionary_only_search?).and_return(false)
+    end
+
     context "when an unknown parameter is provided" do
       let(:params) { { "frog" => "toad" } }
       let(:expected_errors) do


### PR DESCRIPTION
Implements #176. Non-prefixed option parameters are deprecated but still supported; see `SUPPORT_DEPRECATED_OPTION_SYNTAX` in `controllers.rb`. Once this is turned off, the specs added to the end of `api_spec.rb` should be switched from pending to non-pending and vice versa.

@ultrasaurus @siruguri - does this code make sense?
