### PR TITLE
Match from a list of integers

### DIFF
--- a/lib/data_magic/error_checker.rb
+++ b/lib/data_magic/error_checker.rb
@@ -84,6 +84,8 @@ module DataMagic
         case value.to_s
         when /^-?\d+$/
           "integer"
+        when /^(-?\d+,?)+$/ # list of integers
+          "integer"
         when /^-?\d+\.\d+$/
           "float"
         else

--- a/spec/lib/data_magic/error_checker_spec.rb
+++ b/spec/lib/data_magic/error_checker_spec.rb
@@ -123,6 +123,13 @@ describe 'API errors', type: 'feature' do
       end
     end
 
+    context "when a value of the correct type is provided for a field" do
+      context "providing a comma-separated list of integers for an integer field" do
+        let(:params) { { "population" => "10,20,30"} }
+        it_correctly "does not return an error"
+      end
+    end
+
     context "when a range is specified" do
       context "in the wrong format" do
         let(:params) { { "population__range" => "kevin..3" } }

--- a/spec/lib/data_magic/query_builder_spec.rb
+++ b/spec/lib/data_magic/query_builder_spec.rb
@@ -58,6 +58,21 @@ describe DataMagic::QueryBuilder do
     it_correctly "builds a query"
   end
 
+  describe "can exact match from a list of integers" do
+    before do
+      allow(DataMagic.config).to receive(:field_type).with(:age).and_return("integer")
+    end
+    subject { { age: '10,20,40' } }
+    let(:expected_query) do {
+        filtered: {
+            query: { match_all: {} },
+            filter: {
+                terms: { age: [10,20,40] }
+            } } }
+    end
+    it_correctly "builds a query"
+  end
+
   describe "can search within a location" do
     subject { {} }
     let(:options) { { zip: "94132", distance: "30mi" } }

--- a/spec/lib/data_magic/search_spec.rb
+++ b/spec/lib/data_magic/search_spec.rb
@@ -153,5 +153,13 @@ describe "DataMagic #search" do
       response = DataMagic.search({}, sort: "population:asc")
       expect(response["results"][0]['name']).to eq("Rochester")
     end
+
+    it "can match a field on several given integer values" do
+      response = DataMagic.search({population: "8175133,3792621,2695598,"}, sort: "population:desc")
+      expect(response["results"].length).to eq(3)
+      expect(response["results"][0]['name']).to eq("New York")
+      expect(response["results"][1]['name']).to eq("Los Angeles")
+      expect(response["results"][2]['name']).to eq("Chicago")
+    end
   end
 end


### PR DESCRIPTION
Now a comma-separated list of integers can be supplied to any integer field parameter:
```
/v1/schools?id=1,2,3
```
... should return a list of the three records with those IDs.

Implements https://github.com/18F/college-choice/issues/948.