### PR TITLE
Add caching headers

### DIFF
--- a/app/controllers.rb
+++ b/app/controllers.rb
@@ -19,8 +19,7 @@ OpenDataMaker::App.controllers :v1 do
     headers 'Access-Control-Allow-Origin' => '*',
             'Access-Control-Allow-Methods' => ['GET'],
             'Surrogate-Control' => "max-age=#{CACHE_TTL}"
-    expires(CACHE_TTL)
-    cache_control(max_age: CACHE_TTL, s_max_age:CACHE_TTL)
+    cache_control :public, max_age: CACHE_TTL
   end
 
   get :endpoints do

--- a/app/controllers.rb
+++ b/app/controllers.rb
@@ -9,13 +9,18 @@ OpenDataMaker::App.controllers do
   end
 end
 
+CACHE_TTL = 300
+
 # All API requests are prefixed by the API version
 # in this case, "v1" - e.g. "/vi/endpoints" etc.
 OpenDataMaker::App.controllers :v1 do
   before do
     content_type :json
     headers 'Access-Control-Allow-Origin' => '*',
-            'Access-Control-Allow-Methods' => ['GET']
+            'Access-Control-Allow-Methods' => ['GET'],
+            'Surrogate-Control' => "max-age=#{CACHE_TTL}"
+    expires(CACHE_TTL)
+    cache_control(max_age: CACHE_TTL, s_max_age:CACHE_TTL)
   end
 
   get :endpoints do


### PR DESCRIPTION
As discussed in https://github.com/18F/college-choice/issues/990 - this adds
```
Cache-Control: public, max-age=300
Surrogate-Control: max-age=300
```
to all `v1` API headers.

Explanation:
 * We've chosen an initial TTL of five minutes until we're more confident of not needing to rush data fixes.
 * `max-age=300` is the same as `expires` and `s-max-age`.
 * `public` because there's no private info, and an ISP cache should be free to share any results
 * `Surrogate-Control` is only seen by the `api.data.gov` cache, and is the TTL value we'll increase first when we do. (At present there's no easy way for us to flush their cache.)