### PR TITLE
Increase unicorn workers from 1 to 5

### DIFF
--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,3 +1,3 @@
-worker_processes 1
+worker_processes 5
 timeout 30
 preload_app true


### PR DESCRIPTION
This is for testing a scalability bottleneck we're observing in load testing.  If I'm reading the documentation correctly at http://unicorn.bogomips.org/Unicorn/Configurator.html, there is no parallelism in request processing in Unicorn and having this set to 1 implies the server can only serve a single concurrent request at any time.