### PR TITLE
Log ES query time, and show with "debug" option

### DIFF
--- a/app/controllers.rb
+++ b/app/controllers.rb
@@ -66,7 +66,7 @@ end
 # see comment in method body
 def get_search_args_from_params(params)
   options = {}
-  %w(sort fields zip distance page per_page).each do |opt|
+  %w(sort fields zip distance page per_page debug).each do |opt|
     options[opt.to_sym] = params.delete("_#{opt}")
     # TODO: remove next line to end support for un-prefixed option parameters
     options[opt.to_sym] ||= params.delete(opt)

--- a/lib/data_magic.rb
+++ b/lib/data_magic.rb
@@ -77,8 +77,10 @@ module DataMagic
 
     logger.info "FULL_QUERY: #{full_query.inspect}"
 
+    time_start = Time.now.to_f
     result = client.search full_query
-    logger.info "result: #{result.inspect[0..500]}"
+    search_time = Time.now.to_f - time_start
+    logger.info "ES query time (s): #{search_time} ; result: #{result.inspect[0..500]}"
     hits = result["hits"]
     total = hits["total"]
     results = []
@@ -99,13 +101,16 @@ module DataMagic
       end
     end
 
+    metadata = {
+      "total" => total,
+      "page" => query_body[:from] / query_body[:size],
+      "per_page" => query_body[:size]
+    }
+    metadata["search_time"] = search_time if options.has_key? :debug
+
     # assemble a simpler json document to return
     {
-      "metadata" => {
-        "total" => total,
-        "page" => query_body[:from] / query_body[:size],
-        "per_page" => query_body[:size]
-      },
+      "metadata" => metadata,
       "results" => 	results
     }
   end

--- a/lib/data_magic.rb
+++ b/lib/data_magic.rb
@@ -106,7 +106,7 @@ module DataMagic
       "page" => query_body[:from] / query_body[:size],
       "per_page" => query_body[:size]
     }
-    metadata["search_time"] = search_time if options.has_key? :debug
+    metadata["search_time"] = search_time if options[:debug]
 
     # assemble a simpler json document to return
     {


### PR DESCRIPTION
The ES query is now timed and logged; also available in the JSON response if you add `_debug=1` to the URL