### PR TITLE
Disable sessions (therefore CSRF protection) to permit caching

### DIFF
--- a/app/app.rb
+++ b/app/app.rb
@@ -5,7 +5,11 @@ module OpenDataMaker
     register SassInitializer
     register Padrino::Helpers
 
-    enable :sessions
+    # This app is stateless and session cookies prevent caching of API responses
+    disable :sessions
+
+    # This app has no sensitive bits and csrf protection requires sessions
+    disable :protect_from_csrf
 
     if ENV['DATA_AUTH'] and not ENV['DATA_AUTH'].empty?
       auth = ENV['DATA_AUTH']


### PR DESCRIPTION
Presently api.data.gov is unable to cache responses because it considers responses with Set-Cookie headers uncacheable (rightly so).  This app is completely stateless and has no need for session tracking, so this PR disables session support.  Further, CSRF protection is not useful if you have no cookies maintaining an authenticated session (and Padrino gripes if you attempt to disable sessions by itself), so disable that protection as well.