### PR TITLE
Set instances and env var defaults

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -2,7 +2,11 @@
 applications:
 -  name: ccapi-staging
    command: bundle exec puma -C ./config/puma.rb
-   memory: 3G
+   instances: 3
+   memory: 2G
    services:
    - bservice
    - eservice
+   env:
+     MAX_THREADS: 5
+     WEB_CONCURRENCY: 3


### PR DESCRIPTION
Sets reasonable defaults for a Puma-based configuration based on the load testing results in 18F/college-choice#597.  In this configuration we can handle roughly 2400rpm with ES being the bottleneck.

These are defaults only, take effect with every 'cf push', and can be overridden with the cf command line tool.