### PR TITLE
[WIP] Connect to all available ES instances

### DIFF
--- a/lib/data_magic.rb
+++ b/lib/data_magic.rb
@@ -245,12 +245,12 @@ module DataMagic
   def self.client
     if @client.nil?
       if ENV['VCAP_APPLICATION']    # Cloud Foundry
-        logger.info "connect to Cloud Foundry elasticsearch service"
-        eservice = ::CF::App::Credentials.find_by_service_name(ENV['es_service'] || 'eservice')
-        logger.info "eservice: #{eservice.inspect}"
-        service_uri = eservice['url'] || eservice['uri']
-        logger.info "service_uri: #{service_uri}"
-        @client = ::Elasticsearch::Client.new host: service_uri
+        logger.info "connect to Cloud Foundry elasticsearch services"
+        eservices = ::CF::App::Credentials.find_all_by_service_tag('elasticsearch')
+        logger.info "eservices: #{eservices.inspect}"
+        service_uris = eservices.collect { |es| es['uri'] }
+        logger.info "service_uris: #{service_uris}"
+        @client = ::Elasticsearch::Client.new hosts: service_uris
         Stretchy.configure do |c|
           c.client = @client   # use a custom client
         end


### PR DESCRIPTION
Implements #207. This tweaks the ES connection code so it looks for Cloud Foundry services with the `elasticsearch` tag and connects to all of them, rather than a single one. The aim is to round-robin ES requests across the cluster to spread load.