### PR TITLE
increase cache_ttl from 5m to 1h

### DIFF
--- a/app/controllers.rb
+++ b/app/controllers.rb
@@ -9,7 +9,11 @@ OpenDataMaker::App.controllers do
   end
 end
 
-CACHE_TTL = 300
+# Specifies how long resources should be cached (in seconds) by
+# either api.data.gov, intermediate caches, or the user's browser.
+# This should balance risk of caching bad data versus unnecessary
+# hits against the back-end.
+CACHE_TTL = 3600
 
 # All API requests are prefixed by the API version
 # in this case, "v1" - e.g. "/vi/endpoints" etc.


### PR DESCRIPTION
This should improve our cache hit rate a bit and should be merged once we're comfortable with the idea that data corrections could take 1h to fully propagate.