### PR TITLE
Index creation

### DIFF
--- a/API.md
+++ b/API.md
@@ -42,10 +42,8 @@ In this query URL:
  * `schools` is the Endpoint. Note the plural.
  * `.json` is the Format. Note the dot between the Endpoint and Format. Also note that, since JSON is the default output format, we didn't _have_ to specify it.
  * In keeping with standard [URI Query String syntax](https://en.wikipedia.org/wiki/Query_string), the `?` and `&` characters are used to begin and separate the list of query parameters.
- * `school.degrees_awarded.predominant=2,3` is a Field Parameter. In this case,
- it's searching for records which have a `school.degrees_awarded.predominant`
- value of either `2` or `3`.
- * `_fields=id,school.name,2013.student.size` is an Option Parameter, as denoted by the initial underscore character. `_fields` is used to limit the output fields to those in the given list.
+ * `school.degrees_awarded.predominant=2,3` is a Field Parameter. In this case, it's searching for records which have a `school.degrees_awarded.predominant` value of either `2` or `3`.
+ * `_fields=id,school.name,2013.student.size` is an Option Parameter, as denoted by the initial underscore character. `_fields` is used to limit the output fields to those in the given list. We strongly recommend using the `_fields` parameter to reduce the amount of data returned by the API, thus increasing performance.
 
 ### JSON Output Example
 
@@ -86,7 +84,7 @@ A successful query will return a JSON with two top-level elements:
  * **`metadata`**: A JSON Object containing information about the results returned. The metadata fields are:
    * `total`: The total number of records matching the query
    * `page`: The page number for this result set
-   * `per_page`: The number of records returned in a single result set. (For more information about the `page` and `per_page` fields, see the section on [Pagination](#pagination))
+   * `per_page`: The number of records returned in a single result set. (For more information about the `page` and `per_page` fields, see the section on [Pagination](#pagination-with-_page-and-_per_page))
  * **`results`**: A JSON Array of record objects. Due to the use of the `_fields` option in this query, there are only three fields in each record - the three fields specified in the `_fields` parameter. When the `_fields` parameter is omitted, the full record is provided.
 
 ### Error Example
@@ -177,7 +175,7 @@ Open-ended ranges can be performed by omitting one side of the range. For exampl
 
 You can even supply a list of ranges, separated by commas. For example, For example: `2013.student.size__range=..100,1000..2000,5000..` matches on schools which had under 100 students, between 1000 and 2000 students, or over 5000 students.
 
-**Additional Notes:**
+#### Additional Notes on Ranges
 
 * Both integer and floating-point ranges are supported.
 * The left-hand number in a range must be lower than the right-hand number.
@@ -186,3 +184,34 @@ You can even supply a list of ranges, separated by commas. For example, For exam
 ## Option Parameters
 
 You can perform extra refinement and organisation of search results using **option parameters**. These special parameters have names beginning with an underscore character (`_`).
+
+### Limiting Returned Fields with `_fields`
+
+By default, records returned in the query response include all their stored fields. However, you can limit the fields returned with the `_fields` option parameter. This parameter takes a comma-separated list of field names. For example: `_fields=id,school.name,school.state` will return result records that only contain those three fields.
+
+Requesting specific fields in the response will significantly improve performance and reduce JSON traffic, and is recommended.
+
+### Pagination with `_page` and `_per_page`
+
+By default, results are returned in pages of 20 records at a time. To retrieve pages after the first, set the `_page` option parameter to the number of the page you wish to retrieve. Page numbers start at zero; so, to return records 21 through 40, use `_page=1`. Remember that the total number of records available for a given query is given in the `total` field of the top-level `metadata` object.
+
+You can also change the number of records returned per page using the `_per_page` option parameter, up to a maximum of 100 records. Bear in mind, however, that large result pages will increase the amount of JSON returned and reduce the performance of the API.
+
+### Sorting with `_sort`
+
+To sort results by a given field, use the `_sort` option parameter. For example, `_sort=population` will return records sorted by population size, in ascending order.
+
+By default, using the `_sort_` option returns records sorted into ascending order, but you can specify ascending or descending order by appending `:asc` or `:desc` to the field name. For example: `_sort=population:desc`
+
+**Note:** Sorting is only availble on fields with the data type `integer`, `float`, `autocomplete` or `name`.
+
+### Geographic Filtering with `_zip` and `_distance`
+
+When the dataset includes a `location` at the root level (`location.lat` and
+`location.lon`) then the documents will be indexed geographically. You can use the `_zip` and `_distance` options to narrow query results down to those within a geographic area. For example, `_zip=12345&_distance=10mi` will return only those results within 10 miles of the center of the given zip code.
+
+#### Additional Notes on Geographic Filtering
+
+* By default, any number passed in the `_distance` parameter is treated as a number of miles, but you can specify miles or kilometers by appending `mi` or `km` respectively.
+* Distances are calculated from the center of the given zip code, not the boundary.
+* Only U.S. zip codes are supported.

--- a/API.md
+++ b/API.md
@@ -12,8 +12,8 @@ This document explains:
 Each query is expressed as a URL, containing:
 
  * The **URL Path** to the Open Data Maker service, e.g.
- `https://college-choice.18f.gov/` (for Open Data Maker running its own
- server), or  `https://https://api.data.gov/TEST/ed/production` (for Open
+ `https://collegescorecard.ed.gov/` (for Open Data Maker running its own
+ server), or  `https://api.data.gov/ed/collegescorecard/v1/` (for Open
  Data Maker proxied through an API gateway)
  * The **API Version String**. Currently the only supported version string is: `v1`
  * The **Endpoint** representing a particular dataset, e.g. `schools`. Endpoint
@@ -32,12 +32,12 @@ Each query is expressed as a URL, containing:
 Here's an example query URL:
 
 ```
-https://ccapi-production.18f.gov/v1/schools.json?school.degrees_awarded.predominant=2,3&_fields=id,school.name,2013.student.size
+https://api.data.gov/ed/collegescorecard/v1/schools.json?school.degrees_awarded.predominant=2,3&_fields=id,school.name,2013.student.size
 ```
 
 In this query URL:
 
- * `https://ccapi-production.18f.gov/` is the URL Path.
+ * `https://api.data.gov/ed/collegescorecard/v1/` is the URL Path.
  * `v1` is the API Version String, followed by `/`, which separates it from the Endpoint.
  * `schools` is the Endpoint. Note the plural.
  * `.json` is the Format. Note the dot between the Endpoint and Format. Also note that, since JSON is the default output format, we didn't _have_ to specify it.
@@ -94,7 +94,7 @@ A successful query will return a JSON with two top-level elements:
 Let's change the query so as to generate an error when it's executed:
 
 ```
-https://ccapi-production.18f.gov/v1/schools.json?school.degrees_awarded.predominant=frog&_fields=id,school.name,wombat
+https://api.data.gov/ed/collegescorecard/v1/schools.json?school.degrees_awarded.predominant=frog&_fields=id,school.name,wombat
 ```
 
 This is the JSON document returned:

--- a/lib/data_magic/config.rb
+++ b/lib/data_magic/config.rb
@@ -247,14 +247,32 @@ module DataMagic
     # return whether the current config was new and required an update
     def update_indexed_config
       updated = false
-      old_config = nil
       index_name = scoped_index_name
+      if index_needs_update?
+        logger.debug "--------> new config -> new index: #{@data.inspect[0..255]}"
+        DataMagic.client.indices.delete index: index_name if index_exists?
+        DataMagic.create_index(index_name, field_types)  ## DataMagic::Index.create ?
+        DataMagic.client.index index: index_name, type: 'config', id: 1, body: @data
+        updated = true
+      end
+      updated
+    end
+
+
+    def index_exists?(index_name=nil)
+      index_name ||= scoped_index_name
       logger.info "looking for: #{index_name}"
-      index_exists = false
-      if DataMagic.client.indices.exists? index: index_name
-        index_exists = true
+      DataMagic.client.indices.exists? index: index_name
+    end
+
+
+    def index_needs_update?(index_name=nil)
+      index_name ||= scoped_index_name
+      old_config = nil
+      if index_exists?(index_name)
         begin
           response = DataMagic.client.get index: index_name, type: 'config', id: 1
+          logger.debug "+-- DM index exists -- #{response.inspect}"
           old_config = response["_source"]
         rescue Elasticsearch::Transport::Transport::Errors::NotFound
           logger.debug "no prior index configuration"
@@ -262,14 +280,8 @@ module DataMagic
       end
       logger.debug "old config version (from es): #{(old_config.nil? ? old_config : old_config['version']).inspect}"
       logger.debug "new config version (from data.yaml): #{@data['version'].inspect}"
-      if old_config.nil? || old_config["version"] != @data["version"]
-        logger.debug "--------> new config -> new index: #{@data.inspect[0..255]}"
-        DataMagic.client.indices.delete index: index_name if index_exists
-        DataMagic.create_index(index_name, field_types)  ## DataMagic::Index.create ?
-        DataMagic.client.index index: index_name, type: 'config', id: 1, body: @data
-        updated = true
-      end
-      updated
+
+      old_config.nil? || old_config["version"] != @data["version"]
     end
 
 

--- a/lib/data_magic/index.rb
+++ b/lib/data_magic/index.rb
@@ -28,8 +28,9 @@ module DataMagic
 
   # data could be a String or an io stream
   def self.import_csv(data, options={})
-    es_index_name = self.create_index
-    Config.logger.debug "Indexing data -- index_name: #{es_index_name}" #options: #{options}"
+    self.create_index unless config.index_exists?
+    es_index_name = self.config.scoped_index_name
+
     additional_fields = options[:mapping] || {}
     additional_data = options[:add_data]
     Config.logger.debug "additional_data: #{additional_data.inspect}"
@@ -123,8 +124,11 @@ module DataMagic
     options = options.merge(config.options)
 
     es_index_name = self.config.load_datayaml(options[:data_path])
-    logger.info "creating #{es_index_name}"   # TO DO: fix #14
-    create_index es_index_name, config.field_types
+    unless config.index_exists?(es_index_name)
+      logger.info "creating #{es_index_name}"   # TO DO: fix #14
+      create_index es_index_name, config.field_types
+    end
+
     logger.info "files: #{self.config.files}"
     config.files.each_with_index do |filepath, index|
       fname = filepath.split('/').last

--- a/manifest.yml
+++ b/manifest.yml
@@ -7,6 +7,7 @@ applications:
    services:
    - bservice
    - eservice
+   - elk-logger
    env:
      MAX_THREADS: 5
      WEB_CONCURRENCY: 3

--- a/spec/lib/data_magic/create_index_spec.rb
+++ b/spec/lib/data_magic/create_index_spec.rb
@@ -1,0 +1,62 @@
+require 'spec_helper'
+require 'data_magic'
+
+describe "DataMagic #init" do
+  before (:all) do
+    ENV['DATA_PATH'] = './spec/fixtures/import_with_dictionary'
+  end
+
+  after(:each) do
+    DataMagic.destroy
+  end
+
+  context "with no options" do
+    it "creates index only once" do
+      expect(DataMagic).to receive(:create_index).once
+      DataMagic.init
+    end
+
+    it "creates index" do
+      DataMagic.init
+      expect(DataMagic.config.index_exists?).to be true
+    end
+
+    it "does not re-create index with subsequent call to #import_with_dictionary" do
+      expect(DataMagic).to receive(:create_index).once
+      DataMagic.init
+      DataMagic.import_with_dictionary
+    end
+  end
+
+
+  context "with load_now: false" do
+    it "does not call #create_index" do
+      expect(DataMagic).not_to receive(:create_index)
+      DataMagic.init(load_now: false)
+    end
+
+    it "does not create index" do
+      DataMagic.init(load_now: false)
+      expect(DataMagic.config.index_exists?).to be false
+    end
+
+    it "creates index with subsequent call to #import_with_dictionary" do
+      DataMagic.init(load_now: false)
+      DataMagic.import_with_dictionary
+      expect(DataMagic.config.index_exists?).to be true
+    end
+
+    it "creates index with subsequent call to #import_csv" do
+      ENV['DATA_PATH'] = './spec/fixtures/minimal'
+      DataMagic.init(load_now: false)
+      data_str = <<-eos
+      a,b
+      1,2
+      3,4
+      eos
+      data = StringIO.new(data_str)
+      DataMagic.import_csv(data)
+      expect(DataMagic.config.index_exists?).to be true
+    end
+  end
+end


### PR DESCRIPTION
Created a `DataMagic::Config.index_exists?` method to ensure that the
index only gets created once. If the index exists after the app starts
subsequent calls to  `#import_with_dictionary` and `#import_csv`
will not trigger index creation.

On the other hand, if the index is not present on app start, then
those actions will create the index.

The logs look cleaner now as they only report on index creation once. 
I'm not sure if the test coverage is sufficient and covers all possible entry points,
so let me know if more tests are needed. 

Working on issue #135