### PR TITLE
Fix git branch reference in Contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,14 +122,14 @@ Before you submit your pull request consider the following guidelines:
     git push origin my-fix-branch
     ```
 
-* In GitHub, send a pull request to `open-data-maker:master`.
+* In GitHub, send a pull request to `open-data-maker:dev`.
 * If we suggest changes then:
   * Make the required updates.
   * Re-run the  test suite to ensure tests are still passing.
   * Rebase your branch and force push to your GitHub repository (this will update your Pull Request):
 
     ```shell
-    git rebase master -i
+    git rebase dev -i
     git push -f
     ```
 
@@ -156,6 +156,12 @@ After your pull request is merged, you can safely delete your branch and pull th
     ```shell
     git pull --ff upstream dev
     ```
+  Note: this assumes that you have already added the `upstream` remote repository, using this command:
+
+    ```shell
+    git remote add upstream https://github.com/18F/open-data-maker.git
+    ```
+
 
 * For folks with write access to the repo: delete the remote branch on GitHub either through the GitHub web UI or your local shell as follows:
 


### PR DESCRIPTION
An update to the `CONTRIBUTING.md` guide to fix the incorrect reference to the `master` branch for pull requests. 