### PR TITLE
Fix bootstrap script.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -4,12 +4,14 @@
 
 Before you can run Open Data Maker, you'll need to have the following software
 installed on your computer:
-* [Elasticsearch]
+* [Elasticsearch] 1.7.3
 * [Ruby] 2.2.2
+
+**NOTE: The newest version of Elasticsearch 2.0.0 does NOT work with our current code**
 
 ### Mac OS X
 
-On a Mac, we recommend installing Ruby 2.2.2 via [RVM], and Elasticsearch via
+On a Mac, we recommend installing Ruby 2.2.2 via [RVM], and Elasticsearch 1.7.3 via
 [Homebrew]. If you are contributing to development, you will also need [Git].
 If you don't already have these tools, the 18F [laptop] script will install
 them for you.

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -48,10 +48,10 @@ if command -v brew >/dev/null; then
   brew update
 
   brew_tap 'homebrew/services'
+  brew_tap 'homebrew/versions'
+  brew_install_or_upgrade 'elasticsearch17'
 
-  brew_install_or_upgrade 'elasticsearch'
-
-  brew services restart elasticsearch
+  brew services restart elasticsearch17
 
   # elasticsearch takes several seconds to load
   sleep 10


### PR DESCRIPTION
Before, the bootstrap script eagerly installed the most recent version
of elasticsearch. While this is normally a "good thing", open data maker
uses conventions that are no longer supported in elasticsearch 2.0.0

Now, ensure elasticsearch 1.7.3 is installed.  Also, update README to
indicate the current situation.