### PR TITLE
Adds color option to default rake task

### DIFF
--- a/spec/spec.rake
+++ b/spec/spec.rake
@@ -14,7 +14,9 @@ begin
   end
 
   desc "Run complete application spec suite"
-  RSpec::Core::RakeTask.new(:spec)
+  RSpec::Core::RakeTask.new(:spec) do |t|
+    t.rspec_opts = "--color"
+  end
 rescue LoadError
   puts "RSpec is not part of this bundle, skip specs."
 end


### PR DESCRIPTION
        Individual spec tasks use --color as an option, but the default
        `rake spec` did not have this option.

        This commit just adds that option to the top level rspec task.