### PR TITLE
Remove obsolete RunRailsCops rubocop directive

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,6 @@ AllCops:
   Exclude:
     - 'bin/**/*'
     - 'db/**/*'
-  RunRailsCops: true
 Metrics/LineLength:
   Enabled: false
 Style/CommentAnnotation:


### PR DESCRIPTION
Obsolete as of Rubocop 0.36.