### PR TITLE
fix various errors we're seeing in NewRelic

### DIFF
--- a/lib/data_magic.rb
+++ b/lib/data_magic.rb
@@ -138,7 +138,7 @@ module DataMagic
 
     if options[:command] == 'stats'
       # Remove metrics that weren't requested.
-      aggregations = result['aggregations']
+      aggregations = result['aggregations'] || {}
       aggregations.each do |f_name, values|
         if options[:metrics] && options[:metrics].size > 0
           aggregations[f_name] = values.reject { |k, v| !(options[:metrics].include? k) }

--- a/lib/data_magic/error_checker.rb
+++ b/lib/data_magic/error_checker.rb
@@ -109,7 +109,7 @@ module DataMagic
           when 'zipcode_error'
             "The provided zipcode, '#{opts[:input]}', is not valid."
           when 'distance_error'
-            "Distance requires zipcode (none given)."
+            "Use of the 'distance' parameter also requires a 'zip' parameter."
           end
         opts
       end

--- a/spec/lib/data_magic/error_checker_spec.rb
+++ b/spec/lib/data_magic/error_checker_spec.rb
@@ -183,7 +183,7 @@ describe 'API errors', type: 'feature' do
         let(:expected_errors) {
           [{
             error: 'distance_error',
-            message: "Distance requires zipcode (none given).",
+            message: "Use of the 'distance' parameter also requires a 'zip' parameter.",
           }]
         }
         it_correctly "returns an error"

--- a/spec/lib/data_magic/error_checker_spec.rb
+++ b/spec/lib/data_magic/error_checker_spec.rb
@@ -177,16 +177,30 @@ describe 'API errors', type: 'feature' do
       # response, which it shouldn't, because that doesn't matter.
       it_correctly "returns an error"
     end
+    context "when a distance is supplied" do
+      context "and no zip" do
+        let(:options) { { distance: "4" } }
+        let(:expected_errors) {
+          [{
+            error: 'distance_error',
+            message: "Distance requires zipcode (none given).",
+          }]
+        }
+        it_correctly "returns an error"
+
+      end
+    end
+
     context "when a zipcode is supplied" do
 
       context "when an invalid zipcode is provided" do
-        let(:params) { { "zip" => '00002' } }
+        let(:options) { { zip: '00002', distance: "4" } }
         let(:expected_errors) {
           [{
             error: 'zipcode_error',
             message: "The provided zipcode, '00002', is not valid.",
             input: '00002',
-            parameter: 'zip'
+            parameter: :zip
           }]
         }
         it_correctly "returns an error"


### PR DESCRIPTION
Note: the following URLs used to error with stack traces in NewRelic, now have proper json error reporting

- http://localhost:3000/v1/schools?distance=4

```
{
  "errors": [
    {
      "error": "distance_error",
      "message": "Distance requires zipcode (none given)."
    }
  ]
}
```

- http://localhost:3000/v1/schools?zip=000
```
{
  "errors": [
    {
      "error": "zipcode_error",
      "parameter": "zip",
      "input": "000",
      "message": "The provided zipcode, '000', is not valid."   
     }
  ]
}
```