### PR TITLE
Elasticsearch bulk index

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ gem 'actionview'
 gem 'dotenv'
 gem 'oj'
 gem 'parslet'
+gem 'parallel'
 
 # Project requirements
 gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -144,6 +144,7 @@ GEM
       padrino-core (= 0.12.5)
     padrino-support (0.12.5)
       activesupport (>= 3.1)
+    parallel (1.6.1)
     parslet (1.7.1)
       blankslate (>= 2.0, <= 4.0)
     polyglot (0.3.5)
@@ -235,6 +236,7 @@ DEPENDENCIES
   newrelic_rpm
   oj
   padrino (= 0.12.5)
+  parallel
   parslet
   pry
   pry-byebug

--- a/lib/data_magic.rb
+++ b/lib/data_magic.rb
@@ -307,7 +307,7 @@ module DataMagic
     opts = {}
     if ENV['ES_DEBUG']
       tracer = Logger.new(STDOUT)
-      tracer.formatter = ->(_s, _d, _p, m) { "ES - #{m.gsub(/^.*$/) { |n| '   ' + n }}\n" }
+      tracer.formatter = ->(_s, _d, _p, m) { "#{m.gsub(/^.*$/) { |n| '   ' + n }}\n" }
       opts[:tracer] = tracer
     end
     if @client.nil?

--- a/lib/data_magic.rb
+++ b/lib/data_magic.rb
@@ -306,8 +306,8 @@ module DataMagic
   def self.client
     opts = {}
     if ENV['ES_DEBUG']
-      tracer = Logger.new(STDERR)
-      tracer.formatter = ->(_s, _d, _p, m) { "#{m.gsub(/^.*$/) { |n| '   ' + n }}\n" }
+      tracer = Logger.new(STDOUT)
+      tracer.formatter = ->(_s, _d, _p, m) { "ES - #{m.gsub(/^.*$/) { |n| '   ' + n }}\n" }
       opts[:tracer] = tracer
     end
     if @client.nil?

--- a/lib/data_magic/config.rb
+++ b/lib/data_magic/config.rb
@@ -329,8 +329,9 @@ module DataMagic
     def read_from_s3(bucket, key)
       result = nil
       begin
-        response = @s3.get_object(bucket: bucket, key: key)
-        result = response.body.read
+        tmpfile = Tempfile.new(key)
+        response = @s3.get_object(bucket: bucket, key: key, response_target: tmpfile)
+        result = response.body
       rescue Aws::S3::Errors::NoSuchKey
         # we don't want to raise this one, might be expected
         result = nil
@@ -347,7 +348,7 @@ module DataMagic
     def read_path_local(path)
       result = nil
       begin
-        result = File.read(path)
+        result = File.open(path, 'r:bom|utf-8')
       rescue => e
         if e.message.include? "No such file or directory"
           result = nil
@@ -359,7 +360,7 @@ module DataMagic
       result
     end
 
-    # reads a file or s3 object, returns a string
+    # opens a file or s3 object, returns an IO stream
     # path follows URI pattern
     # could be
     #   s3://username:password@bucket_name/path

--- a/lib/data_magic/index.rb
+++ b/lib/data_magic/index.rb
@@ -8,6 +8,7 @@ require_relative 'index/document_builder'
 require_relative 'index/importer'
 require_relative 'index/output'
 require_relative 'index/repository'
+require_relative 'index/row_importer'
 require_relative 'index/super_client'
 
 require 'action_view'  # for distance_of_time_in_words (logging time)

--- a/lib/data_magic/index/importer.rb
+++ b/lib/data_magic/index/importer.rb
@@ -78,6 +78,10 @@ module DataMagic
               RowImporter.process(row, self)
             end
           end
+          if !headers
+            single_document = DocumentBuilder.create(chunk.first, builder_data, DataMagic.config)
+            set_headers(single_document)
+          end
           increment(chunk.size)
         end
       end

--- a/lib/data_magic/index/output.rb
+++ b/lib/data_magic/index/output.rb
@@ -13,13 +13,12 @@ module DataMagic
         @headers = doc.headers
       end
 
-
       def skipping(id)
         skipped << id
       end
 
-      def increment
-        @row_count += 1
+      def increment(count = 1)
+        @row_count += count
       end
 
       def validate!

--- a/spec/lib/data_magic/config_spec.rb
+++ b/spec/lib/data_magic/config_spec.rb
@@ -36,7 +36,7 @@ describe DataMagic::Config do
         status: 200
       )
       allow(fake_s3).to receive(:get_object)
-        .with(bucket: 'mybucket', key: 'data.yaml')
+        .with(bucket: 'mybucket', key: 'data.yaml', response_target: duck_type(:read))
         .and_return(fake_get_object_response)
       config = DataMagic::Config.new(s3: fake_s3)
       expect(config.s3).to eq(fake_s3)
@@ -48,7 +48,7 @@ describe DataMagic::Config do
       fake_s3 = class_spy("Fake Aws::S3::Client")
 
       allow(fake_s3).to receive(:get_object)
-        .with(bucket: 'mybucket', key: 'data.yaml')
+        .with(bucket: 'mybucket', key: 'data.yaml', response_target: duck_type(:read))
         .and_raise(RuntimeError)
       expect {
         DataMagic::Config.new(s3: fake_s3)

--- a/spec/lib/data_magic/index/importer_spec.rb
+++ b/spec/lib/data_magic/index/importer_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+require 'data_magic'
+
+describe "DataMagic::Index::Importer" do
+  before do
+    ENV['DATA_PATH'] = './spec/fixtures/minimal'
+    DataMagic.init(load_now: false)
+  end
+  after do
+    DataMagic.destroy
+  end
+
+  it "indexes in parallel based on NPROCS" do
+    stub_const('ENV', { 'NPROCS' => '2' })
+
+    data_str = <<-eos
+a,b
+1,2
+3,4
+eos
+    data = StringIO.new(data_str)
+    num_rows, fields = DataMagic.import_csv(data)
+    expect(num_rows).to be(2)
+    expect(fields).to eq(['a', 'b'])
+  end
+end


### PR DESCRIPTION
re-implements #94 
supersedes #295 and #296 (rebased on dev)

This PR cuts indexing time significantly when run on a machine with multiple processors, at the expense of more memory usage. To mitigate the additional memory use that comes with parallel (forked) processes, CSV files are read via IO stream, a row at a time, rather than being slurped entirely into memory and parsed as a String.

For reference, the current import consumes about 250MB for the single process.

Example stats and usage:

```
# for 1000 rows from 4 files (using college-choice-data)

NPROCS=1 rake import
# 812 sec (memory 150MB)

NPROCS=4 CHUNK_SIZE=50 rake import
# 396 sec (memory 180MB x 4 (720MB))

NPROCS=5 CHUNK_SIZE=100 rake import
# 268 sec (memory 230MB x 5 (1150MB))
```

An important caveat with reading CSV as stream: the :force_utf8 feature does not work as currently implemented. My recommendation is to require all CSV files be in UTF-8 format prior to import, possibly offering some easy docs/script to convert encodings.