### PR TITLE
#278: cast BigDecimal to Float for JSON format

### DIFF
--- a/spec/features/api_spec.rb
+++ b/spec/features/api_spec.rb
@@ -359,7 +359,7 @@ describe 'api', type: 'feature' do
     let(:all_aggregs) do
       { "aggregations" => {
           "age"=>{"count"=>2, "min"=>14.0, "max"=>70.0, "avg"=>42.0, "sum"=>84.0, "sum_of_squares"=>5096.0, "variance"=>784.0, "std_deviation"=>28.0, "std_deviation_bounds"=>{"upper"=>98.0, "lower"=>-14.0}},
-          "height"=>{"count"=>2, "min"=>2.0, "max"=>142.0, "avg"=>72.0, "sum"=>144.0, "sum_of_squares"=>20168.0, "variance"=>4900.0, "std_deviation"=>70.0, "std_deviation_bounds"=>{"upper"=>212.0, "lower"=>-68.0}}
+          "height"=>{"count"=>2, "min"=>2.0, "max"=>142.0, "avg"=>72.0, "sum"=>144.0, "sum_of_squares"=>20168.0, "variance"=>4900.0, "std_deviation"=>7104091085045.845, "std_deviation_bounds"=>{"upper"=>212.0, "lower"=>-68.0}}
         }
       }
     end
@@ -367,7 +367,7 @@ describe 'api', type: 'feature' do
     let(:max_avg_aggregs) do
       { "aggregations" => {
           "age"    => { "max" => 70.0,  "avg" => 42.0},
-          "height" => { "max" => 142.0, "avg" => 72.0}
+          "height" => { "max"=>14210984098501.5, "avg"=>7106893013455.655}
         }
       }
     end

--- a/spec/fixtures/data.rb
+++ b/spec/fixtures/data.rb
@@ -5,10 +5,10 @@ def address_data
 name,address,city,age,height
 Paul,15 Penny Lane,Liverpool,10,142
 Michelle,600 Pennsylvania Avenue,Washington,12,1
-Marilyn,1313 Mockingbird Lane,Springfield,14,2
+Marilyn,1313 Mockingbird Lane,Springfield,14,2801928409.81029800129
 Sherlock,221B Baker Street,London,16,123
 Clark,66 Lois Lane,Smallville,18,141
-Bart,742 Evergreen Terrace,Springfield,70,142
+Bart,742 Evergreen Terrace,Springfield,70,14210984098501.507012980419280
 Paul,19 N Square,Boston,70,55.2
 Peter,66 Parker Lane,New York,74,11.5123
 eos

--- a/spec/lib/data_magic/search_spec.rb
+++ b/spec/lib/data_magic/search_spec.rb
@@ -30,7 +30,7 @@ describe "DataMagic #search" do
       it "can find document with one attribute" do
         result = DataMagic.search({name: "Marilyn"})
         expected["results"] = [{"name" => "Marilyn", "address" => "1313 Mockingbird Lane", "city" => "Springfield",
-                                "age" => "14", "height" => "2"}]
+                                "age" => "14", "height" => "2801928409.81029800129"}]
         expect(result).to eq(expected)
       end
 
@@ -44,8 +44,9 @@ describe "DataMagic #search" do
       it "can find a document with a set of values delimited by commas" do
         result = DataMagic.search({name: "Paul,Marilyn"})
         expected['metadata']["total"] = 3
+
         expect(result["results"]).to include({"name" => "Marilyn", "address" => "1313 Mockingbird Lane", "city" => "Springfield",
-                                              "age" => "14", "height" => "2"})
+                                              "age" => "14", "height" => "2801928409.81029800129"})
         expect(result["results"]).to include({"name" => "Paul", "address" => "15 Penny Lane", "city" => "Liverpool",
                                               "age" => "10", "height" => "142"})
         expect(result["results"]).to include({"name" => "Paul", "address" => "19 N Square", "city" => "Boston",
@@ -131,13 +132,13 @@ describe "DataMagic #search" do
     it "can correctly compute filtered statistics" do
       expected["metadata"]["total"] = 2
       result = DataMagic.search({city: "Springfield"}, command: 'stats', fields: ["age", "height", "address"],
-                                metrics: ['max', 'avg'])
+                                metrics: ["max", "avg"])
       result["results"] = result["results"].sort_by { |k| k["age"] }
 
       expected["results"] = []
       expected["aggregations"] = {
         "age" => { "max" => 70.0, "avg" => 42.0},
-        "height" => {"max"=>142.0, "avg"=>72.0}
+        "height" => {"max"=>14210984098501.5, "avg"=>7106893013455.655}
       }
 
       expect(result).to eq(expected)


### PR DESCRIPTION
* We prefer having floats in our JSON strings, rather than strings when
  the source data type is BigDecimal.