### PR TITLE
Support Elasticsearch date types in import

### DIFF
--- a/lib/data_magic.rb
+++ b/lib/data_magic.rb
@@ -227,6 +227,7 @@ module DataMagic
   # convert the types from data.yaml to Elasticsearch-specific types
   def self.es_field_types(field_types)
     custom_type = {
+      'date' => {type: 'date', format: "yyyy-MM-dd"},
       'literal' => {type: 'string', index:'not_analyzed'},
       'name' => {type: 'string', index:'not_analyzed'},
       'lowercase_name' => {type: 'string', index:'not_analyzed', store: false},

--- a/spec/lib/data_magic_spec.rb
+++ b/spec/lib/data_magic_spec.rb
@@ -24,6 +24,13 @@ describe DataMagic do
       end
     end
 
+    context 'with type "date"' do
+      it 'returns the date field with date type in default format' do
+        expect(described_class.es_field_types({ 'date' => 'date' }))
+        .to eq({"date"=>{:type=>"date",:format=>"yyyy-MM-dd"}})                                       
+      end
+    end
+
   end
 
 end


### PR DESCRIPTION
This commit modifies the DataMagic module to support the Elasticsearch
"date"
datatype (https://www.elastic.co/guide/en/elasticsearch/reference/current/date.html).

This commit responds directly to the open issue #105 (support date
type). It does not incorporate any of the work done in the issue closed
as #128 ([WIP] Add date type to map_field_types method -- not tested).