### PR TITLE
allow for multiple null_value mappings in the data dictionary

### DIFF
--- a/lib/data_magic/index/document_builder.rb
+++ b/lib/data_magic/index/document_builder.rb
@@ -50,16 +50,17 @@ module DataMagic
 
         # row: a hash  (keys may be strings or symbols)
         # valid_types: an array of allowed types
+        # null_value: row values that will map to null
         # field_types: hash field_name : type (float, integer, string)
         # returns a hash where values have been coerced to the new type
         # TODO: move type validation to config load time instead
         def map_column_types(row, config)
           valid_types = config.valid_types
-          null_value = config.null_value || null_value = 'NULL'
+          null_value = [*config.null_value] || ['NULL']
 
           mapped = {}
           row.each do |key, value|
-            if value == null_value
+            if null_value.include? value
               mapped[key] = nil
             else
               type = config.csv_column_type(key)

--- a/lib/data_magic/index/document_builder.rb
+++ b/lib/data_magic/index/document_builder.rb
@@ -77,6 +77,7 @@ module DataMagic
         def lowercase_columns(row, field_types = {})
           new_columns = {}
           row.each do |key, value|
+            next if value.nil?
             type = field_types[key.to_sym] || field_types[key.to_s]
             new_columns["_#{key}"] = value.downcase if type == "name" || type == "autocomplete"
           end

--- a/spec/lib/data_magic/index/document_builder_spec.rb
+++ b/spec/lib/data_magic/index/document_builder_spec.rb
@@ -34,6 +34,33 @@ describe DataMagic::Index::DocumentBuilder do
     end
   end
 
+  context "with custom null_value" do
+
+    describe "a single null_value mapping" do
+      before do
+        allow(config).to receive(:null_value).and_return(["NULL"])
+      end
+
+      subject {{ name: 'Smithville', sometimesNULL: 'NULL'  }}
+      let(:expected_document) {{ 'name' => 'Smithville',
+                                 'sometimesNULL' => nil }}
+      it_correctly "creates a document"
+    end
+
+    describe "multiple null_value mappings" do
+      before do
+        allow(config).to receive(:null_value).and_return(["NULL","CustomNull"])
+      end
+
+      subject {{ name: 'Smithville', maybeNull: 'CustomNull', sometimesNULL: 'NULL'  }}
+      let(:expected_document) {{ 'name' => 'Smithville',
+                                 'maybeNull' => nil,
+                                 'sometimesNULL' => nil }}
+      it_correctly "creates a document"
+    end
+
+  end
+
   context "with type mapping" do
     describe "integer" do
       before do


### PR DESCRIPTION
This PR addresses the need for multiple field values to map to a `NULL` value in the API. This 
is related to 18F/college-choice#903.

Currently, [config.null_value](https://github.com/18F/open-data-maker/blob/dev/lib/data_magic/config.rb#L465-L467) and [map_column_types](https://github.com/18F/open-data-maker/blob/dev/lib/data_magic/index/document_builder.rb#L62) methods only allow for a single string value in the data dictionary to be mapped to null when encountered in the csv data during import. The default has been the string `"NULL"` if no data dictionary entry was found.

This PR allows for the `null_value` to be defined as an array OR a single entry when the column type's are mapped and will give more flexibility for other field value instances that should be mapped to null.
